### PR TITLE
Implement CRUD for contatos

### DIFF
--- a/app/models/contato.py
+++ b/app/models/contato.py
@@ -1,0 +1,15 @@
+from app import db
+
+
+class Contato(db.Model):
+    __tablename__ = "contatos"
+
+    contato_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    telefone_principal = db.Column(db.String(20))
+    telefone_principal_whatsapp = db.Column(db.Boolean)
+    telefone_principal_nome_contato = db.Column(db.String(100))
+    telefone_alternativo = db.Column(db.String(20))
+    telefone_alternativo_whatsapp = db.Column(db.Boolean)
+    telefone_alternativo_nome_contato = db.Column(db.String(100))
+    email_responsavel = db.Column(db.String(100))

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,4 +1,6 @@
 from app.routes.familia import bp as familia_bp
+from app.routes.contato import bp as contato_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
+    app.register_blueprint(contato_bp)

--- a/app/routes/contato.py
+++ b/app/routes/contato.py
@@ -1,0 +1,61 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.contato import Contato
+from app.schemas.contato import ContatoSchema
+from app import db
+
+bp = Blueprint("contatos", __name__, url_prefix="/contatos")
+
+contato_schema = ContatoSchema()
+contatos_schema = ContatoSchema(many=True)
+
+
+@bp.route("", methods=["POST"])
+def criar_contato():
+    data = request.get_json()
+    try:
+        novo_contato = contato_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(novo_contato)
+    db.session.commit()
+    return contato_schema.jsonify(novo_contato), 201
+
+
+@bp.route("", methods=["GET"])
+def listar_contatos():
+    contatos = Contato.query.all()
+    return contatos_schema.jsonify(contatos), 200
+
+
+@bp.route("/<int:contato_id>", methods=["GET"])
+def obter_contato(contato_id):
+    contato = db.session.get(Contato, contato_id)
+    if not contato:
+        return jsonify({"mensagem": "Contato não encontrado"}), 404
+    return contato_schema.jsonify(contato)
+
+
+@bp.route("/<int:contato_id>", methods=["PUT"])
+def atualizar_contato(contato_id):
+    contato = db.session.get(Contato, contato_id)
+    if not contato:
+        return jsonify({"mensagem": "Contato não encontrado"}), 404
+
+    data = request.get_json()
+    contato = contato_schema.load(data, instance=contato, partial=True)
+
+    db.session.commit()
+    return contato_schema.jsonify(contato)
+
+
+@bp.route("/<int:contato_id>", methods=["DELETE"])
+def deletar_contato(contato_id):
+    contato = db.session.get(Contato, contato_id)
+    if not contato:
+        return jsonify({"mensagem": "Contato não encontrado"}), 404
+
+    db.session.delete(contato)
+    db.session.commit()
+    return jsonify({"mensagem": "Contato deletado com sucesso"}), 200

--- a/app/schemas/contato.py
+++ b/app/schemas/contato.py
@@ -1,0 +1,18 @@
+from app import ma
+from app.models.contato import Contato
+
+
+class ContatoSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = Contato
+        load_instance = True
+
+    contato_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    telefone_principal = ma.auto_field()
+    telefone_principal_whatsapp = ma.auto_field()
+    telefone_principal_nome_contato = ma.auto_field()
+    telefone_alternativo = ma.auto_field()
+    telefone_alternativo_whatsapp = ma.auto_field()
+    telefone_alternativo_nome_contato = ma.auto_field()
+    email_responsavel = ma.auto_field()

--- a/tests/test_contato_routes.py
+++ b/tests/test_contato_routes.py
@@ -1,0 +1,96 @@
+import pytest
+from app import create_app
+
+_familia_id_contato = None
+_contato_id_gerado = None
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def test_post_contato(client):
+    global _familia_id_contato, _contato_id_gerado
+
+    familia_payload = {
+        "nome_responsavel": "Contato Familia",
+        "data_nascimento": "1985-05-05",
+        "genero": "Feminino",
+        "genero_autodeclarado": "Mulher",
+        "estado_civil": "Solteira",
+        "rg": "111111111",
+        "cpf": "677.770.280-75",
+        "autoriza_uso_imagem": True,
+    }
+    resp_familia = client.post("/familias", json=familia_payload)
+    assert resp_familia.status_code == 201
+    _familia_id_contato = resp_familia.get_json()["familia_id"]
+
+    payload = {
+        "familia_id": _familia_id_contato,
+        "telefone_principal": "11999999999",
+        "telefone_principal_whatsapp": True,
+        "telefone_principal_nome_contato": "Responsavel",
+        "telefone_alternativo": "11888888888",
+        "telefone_alternativo_whatsapp": False,
+        "telefone_alternativo_nome_contato": "Alternativo",
+        "email_responsavel": "email@exemplo.com",
+    }
+
+    response = client.post("/contatos", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "contato_id" in data
+    _contato_id_gerado = data["contato_id"]
+
+
+def test_get_contatos(client):
+    response = client.get("/contatos")
+    assert response.status_code == 200
+
+
+def test_get_contato_por_id(client):
+    global _contato_id_gerado
+    response = client.get(f"/contatos/{_contato_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["contato_id"] == _contato_id_gerado
+
+
+def test_put_contato(client):
+    global _contato_id_gerado
+    update_payload = {
+        "telefone_principal_nome_contato": "Nome Atualizado",
+    }
+    response = client.put(f"/contatos/{_contato_id_gerado}", json=update_payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["telefone_principal_nome_contato"] == "Nome Atualizado"
+
+
+def test_delete_contato(client):
+    global _contato_id_gerado
+    response = client.delete(f"/contatos/{_contato_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["mensagem"] == "Contato deletado com sucesso"
+
+
+def test_get_contato_depois_do_delete(client):
+    global _contato_id_gerado
+    response = client.get(f"/contatos/{_contato_id_gerado}")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["mensagem"] == "Contato não encontrado"
+
+
+def test_cleanup_familia(client):
+    global _familia_id_contato
+    if _familia_id_contato:
+        client.delete(f"/familias/{_familia_id_contato}")


### PR DESCRIPTION
## Summary
- add Contato model
- create ContatoSchema
- implement Blueprint for contatos CRUD endpoints
- register contatos blueprint
- add pytest suite covering contato endpoints

## Testing
- `pytest -q` *(fails: can't open ODBC driver)*

------
https://chatgpt.com/codex/tasks/task_e_6846a76559e88320a03ec93ca16dcdc7