### PR TITLE
Implement composicao_familiar CRUD

### DIFF
--- a/app/models/composicao_familiar.py
+++ b/app/models/composicao_familiar.py
@@ -1,0 +1,15 @@
+from app import db
+
+class ComposicaoFamiliar(db.Model):
+    __tablename__ = "composicao_familiar"
+
+    composicao_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    total_residentes = db.Column(db.Integer)
+    quantidade_bebes = db.Column(db.Integer)
+    quantidade_criancas = db.Column(db.Integer)
+    quantidade_adolescentes = db.Column(db.Integer)
+    quantidade_adultos = db.Column(db.Integer)
+    quantidade_idosos = db.Column(db.Integer)
+    tem_menores_na_escola = db.Column(db.Boolean)
+    motivo_ausencia_escola = db.Column(db.Text)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,6 +1,8 @@
 from app.routes.familia import bp as familia_bp
 from app.routes.contato import bp as contato_bp
+from app.routes.composicao_familiar import bp as composicao_familiar_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
     app.register_blueprint(contato_bp)
+    app.register_blueprint(composicao_familiar_bp)

--- a/app/routes/composicao_familiar.py
+++ b/app/routes/composicao_familiar.py
@@ -1,0 +1,61 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.composicao_familiar import ComposicaoFamiliar
+from app.schemas.composicao_familiar import ComposicaoFamiliarSchema
+from app import db
+
+bp = Blueprint("composicao_familiar", __name__, url_prefix="/composicao_familiar")
+
+composicao_schema = ComposicaoFamiliarSchema()
+composicoes_schema = ComposicaoFamiliarSchema(many=True)
+
+
+@bp.route("", methods=["POST"])
+def criar_composicao():
+    data = request.get_json()
+    try:
+        nova_composicao = composicao_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(nova_composicao)
+    db.session.commit()
+    return composicao_schema.jsonify(nova_composicao), 201
+
+
+@bp.route("", methods=["GET"])
+def listar_composicoes():
+    composicoes = ComposicaoFamiliar.query.all()
+    return composicoes_schema.jsonify(composicoes), 200
+
+
+@bp.route("/<int:composicao_id>", methods=["GET"])
+def obter_composicao(composicao_id):
+    composicao = db.session.get(ComposicaoFamiliar, composicao_id)
+    if not composicao:
+        return jsonify({"mensagem": "Composicao familiar não encontrada"}), 404
+    return composicao_schema.jsonify(composicao)
+
+
+@bp.route("/<int:composicao_id>", methods=["PUT"])
+def atualizar_composicao(composicao_id):
+    composicao = db.session.get(ComposicaoFamiliar, composicao_id)
+    if not composicao:
+        return jsonify({"mensagem": "Composicao familiar não encontrada"}), 404
+
+    data = request.get_json()
+    composicao = composicao_schema.load(data, instance=composicao, partial=True)
+
+    db.session.commit()
+    return composicao_schema.jsonify(composicao)
+
+
+@bp.route("/<int:composicao_id>", methods=["DELETE"])
+def deletar_composicao(composicao_id):
+    composicao = db.session.get(ComposicaoFamiliar, composicao_id)
+    if not composicao:
+        return jsonify({"mensagem": "Composicao familiar não encontrada"}), 404
+
+    db.session.delete(composicao)
+    db.session.commit()
+    return jsonify({"mensagem": "Composicao deletada com sucesso"}), 200

--- a/app/schemas/composicao_familiar.py
+++ b/app/schemas/composicao_familiar.py
@@ -1,0 +1,18 @@
+from app import ma
+from app.models.composicao_familiar import ComposicaoFamiliar
+
+class ComposicaoFamiliarSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = ComposicaoFamiliar
+        load_instance = True
+
+    composicao_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    total_residentes = ma.auto_field()
+    quantidade_bebes = ma.auto_field()
+    quantidade_criancas = ma.auto_field()
+    quantidade_adolescentes = ma.auto_field()
+    quantidade_adultos = ma.auto_field()
+    quantidade_idosos = ma.auto_field()
+    tem_menores_na_escola = ma.auto_field()
+    motivo_ausencia_escola = ma.auto_field()

--- a/tests/test_composicao_familiar_routes.py
+++ b/tests/test_composicao_familiar_routes.py
@@ -1,0 +1,100 @@
+import pytest
+from app import create_app
+
+_familia_id_composicao = None
+_composicao_id_gerado = None
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def test_post_composicao_familiar(client):
+    global _familia_id_composicao, _composicao_id_gerado
+
+    payload = {
+        "nome_responsavel": "Teste Pytest",
+        "data_nascimento": "1990-01-01",
+        "genero": "Masculino",
+        "genero_autodeclarado": "Homem",
+        "estado_civil": "Solteiro",
+        "rg": "999999999",
+        "cpf": "794.134.270-70",
+        "autoriza_uso_imagem": True,
+    }
+
+    response = client.post("/familias", json=payload)
+    assert response.status_code == 201
+
+    data = response.get_json()
+    _familia_id_composicao = data["familia_id"]
+
+    payload = {
+        "familia_id": _familia_id_composicao,
+        "total_residentes": 4,
+        "quantidade_bebes": 1,
+        "quantidade_criancas": 1,
+        "quantidade_adolescentes": 1,
+        "quantidade_adultos": 1,
+        "quantidade_idosos": 0,
+        "tem_menores_na_escola": True,
+        "motivo_ausencia_escola": "N/A",
+    }
+
+    response = client.post("/composicao_familiar", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "composicao_id" in data
+    _composicao_id_gerado = data["composicao_id"]
+
+
+def test_get_composicoes(client):
+    response = client.get("/composicao_familiar")
+    assert response.status_code == 200
+
+
+def test_get_composicao_por_id(client):
+    global _composicao_id_gerado
+    response = client.get(f"/composicao_familiar/{_composicao_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["composicao_id"] == _composicao_id_gerado
+
+
+def test_put_composicao(client):
+    global _composicao_id_gerado
+    update_payload = {"total_residentes": 5}
+    response = client.put(
+        f"/composicao_familiar/{_composicao_id_gerado}", json=update_payload
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["total_residentes"] == 5
+
+
+def test_delete_composicao(client):
+    global _composicao_id_gerado
+    response = client.delete(f"/composicao_familiar/{_composicao_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["mensagem"] == "Composicao deletada com sucesso"
+
+
+def test_get_composicao_depois_do_delete(client):
+    global _composicao_id_gerado
+    response = client.get(f"/composicao_familiar/{_composicao_id_gerado}")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["mensagem"] == "Composicao familiar não encontrada"
+
+
+def test_cleanup_familia(client):
+    global _familia_id_composicao
+    if _familia_id_composicao:
+        client.delete(f"/familias/{_familia_id_composicao}")


### PR DESCRIPTION
## Summary
- add model, schema and routes for composicao_familiar
- register blueprint
- create tests for composicao_familiar
- update "composicao" error messages to "composicao familiar"

## Testing
- `pytest -q` *(fails: DBAPIError can't open ODBC driver)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae4585e88320a25fea32f637767c