### PR TITLE
Implement educacao_entrevistado CRUD

### DIFF
--- a/app/models/educacao_entrevistado.py
+++ b/app/models/educacao_entrevistado.py
@@ -1,0 +1,10 @@
+from app import db
+
+class EducacaoEntrevistado(db.Model):
+    __tablename__ = "educacao_entrevistado"
+
+    educacao_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    nivel_escolaridade = db.Column(db.String(100))
+    estuda_atualmente = db.Column(db.String(3))
+    curso_ou_serie_atual = db.Column(db.Text)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -2,9 +2,11 @@ from app.routes.familia import bp as familia_bp
 from app.routes.contato import bp as contato_bp
 from app.routes.composicao_familiar import bp as composicao_familiar_bp
 from app.routes.condicoes_moradia import bp as condicoes_moradia_bp
+from app.routes.educacao_entrevistado import bp as educacao_entrevistado_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
     app.register_blueprint(contato_bp)
     app.register_blueprint(composicao_familiar_bp)
     app.register_blueprint(condicoes_moradia_bp)
+    app.register_blueprint(educacao_entrevistado_bp)

--- a/app/routes/educacao_entrevistado.py
+++ b/app/routes/educacao_entrevistado.py
@@ -1,0 +1,61 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.educacao_entrevistado import EducacaoEntrevistado
+from app.schemas.educacao_entrevistado import EducacaoEntrevistadoSchema
+from app import db
+
+bp = Blueprint("educacao_entrevistado", __name__, url_prefix="/educacao_entrevistado")
+
+educacao_schema = EducacaoEntrevistadoSchema()
+educacoes_schema = EducacaoEntrevistadoSchema(many=True)
+
+
+@bp.route("", methods=["POST"])
+def criar_educacao():
+    data = request.get_json()
+    try:
+        nova_educacao = educacao_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(nova_educacao)
+    db.session.commit()
+    return educacao_schema.jsonify(nova_educacao), 201
+
+
+@bp.route("", methods=["GET"])
+def listar_educacoes():
+    educacoes = EducacaoEntrevistado.query.all()
+    return educacoes_schema.jsonify(educacoes), 200
+
+
+@bp.route("/<int:educacao_id>", methods=["GET"])
+def obter_educacao(educacao_id):
+    educacao = db.session.get(EducacaoEntrevistado, educacao_id)
+    if not educacao:
+        return jsonify({"mensagem": "Educação do entrevistado não encontrada"}), 404
+    return educacao_schema.jsonify(educacao)
+
+
+@bp.route("/<int:educacao_id>", methods=["PUT"])
+def atualizar_educacao(educacao_id):
+    educacao = db.session.get(EducacaoEntrevistado, educacao_id)
+    if not educacao:
+        return jsonify({"mensagem": "Educação do entrevistado não encontrada"}), 404
+
+    data = request.get_json()
+    educacao = educacao_schema.load(data, instance=educacao, partial=True)
+
+    db.session.commit()
+    return educacao_schema.jsonify(educacao)
+
+
+@bp.route("/<int:educacao_id>", methods=["DELETE"])
+def deletar_educacao(educacao_id):
+    educacao = db.session.get(EducacaoEntrevistado, educacao_id)
+    if not educacao:
+        return jsonify({"mensagem": "Educação do entrevistado não encontrada"}), 404
+
+    db.session.delete(educacao)
+    db.session.commit()
+    return jsonify({"mensagem": "Educação do entrevistado deletada com sucesso"}), 200

--- a/app/schemas/educacao_entrevistado.py
+++ b/app/schemas/educacao_entrevistado.py
@@ -1,0 +1,14 @@
+from app import ma
+from app.models.educacao_entrevistado import EducacaoEntrevistado
+
+
+class EducacaoEntrevistadoSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = EducacaoEntrevistado
+        load_instance = True
+
+    educacao_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    nivel_escolaridade = ma.auto_field()
+    estuda_atualmente = ma.auto_field()
+    curso_ou_serie_atual = ma.auto_field()

--- a/tests/test_educacao_entrevistado_routes.py
+++ b/tests/test_educacao_entrevistado_routes.py
@@ -1,0 +1,97 @@
+import pytest
+from app import create_app
+
+_familia_id_educacao = None
+_educacao_id_gerada = None
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def test_post_educacao_entrevistado(client):
+    global _familia_id_educacao, _educacao_id_gerada
+
+    payload_familia = {
+        "nome_responsavel": "Teste Pytest",
+        "data_nascimento": "1990-01-01",
+        "genero": "Masculino",
+        "genero_autodeclarado": "Homem",
+        "estado_civil": "Solteiro",
+        "rg": "999999999",
+        "cpf": "794.134.270-70",
+        "autoriza_uso_imagem": True,
+    }
+
+    response = client.post("/familias", json=payload_familia)
+    assert response.status_code == 201
+    data = response.get_json()
+    _familia_id_educacao = data["familia_id"]
+
+    payload = {
+        "familia_id": _familia_id_educacao,
+        "nivel_escolaridade": "Ensino Médio",
+        "estuda_atualmente": "Sim",
+        "curso_ou_serie_atual": "3º ano",
+    }
+
+    response = client.post("/educacao_entrevistado", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "educacao_id" in data
+    _educacao_id_gerada = data["educacao_id"]
+
+
+def test_get_educacoes(client):
+    response = client.get("/educacao_entrevistado")
+    assert response.status_code == 200
+
+
+def test_get_educacao_por_id(client):
+    global _educacao_id_gerada
+    response = client.get(f"/educacao_entrevistado/{_educacao_id_gerada}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["educacao_id"] == _educacao_id_gerada
+
+
+def test_put_educacao(client):
+    global _educacao_id_gerada
+    update_payload = {"nivel_escolaridade": "Superior"}
+    response = client.put(
+        f"/educacao_entrevistado/{_educacao_id_gerada}", json=update_payload
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["nivel_escolaridade"] == "Superior"
+
+
+def test_delete_educacao(client):
+    global _educacao_id_gerada
+    response = client.delete(f"/educacao_entrevistado/{_educacao_id_gerada}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert (
+        data["mensagem"]
+        == "Educação do entrevistado deletada com sucesso"
+    )
+
+
+def test_get_educacao_depois_do_delete(client):
+    global _educacao_id_gerada
+    response = client.get(f"/educacao_entrevistado/{_educacao_id_gerada}")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["mensagem"] == "Educação do entrevistado não encontrada"
+
+
+def test_cleanup_familia(client):
+    global _familia_id_educacao
+    if _familia_id_educacao:
+        client.delete(f"/familias/{_familia_id_educacao}")


### PR DESCRIPTION
## Summary
- add EducacaoEntrevistado model, schema and routes
- register educacao_entrevistado blueprint
- cover new endpoints with pytest

## Testing
- `pytest -q` *(fails: ODBC driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846b3637a4c832091c75034e0083011