### PR TITLE
Implement saude_familiar CRUD

### DIFF
--- a/app/models/saude_familiar.py
+++ b/app/models/saude_familiar.py
@@ -1,0 +1,14 @@
+from app import db
+
+class SaudeFamiliar(db.Model):
+    __tablename__ = "saude_familiar"
+
+    saude_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    tem_doenca_cronica = db.Column(db.Boolean)
+    descricao_doenca_cronica = db.Column(db.Text)
+    usa_medicacao_continua = db.Column(db.Boolean)
+    descricao_medicacao = db.Column(db.Text)
+    tem_deficiencia = db.Column(db.Boolean)
+    descricao_deficiencia = db.Column(db.Text)
+    recebe_bpc = db.Column(db.Boolean)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -2,9 +2,11 @@ from app.routes.familia import bp as familia_bp
 from app.routes.contato import bp as contato_bp
 from app.routes.composicao_familiar import bp as composicao_familiar_bp
 from app.routes.condicoes_moradia import bp as condicoes_moradia_bp
+from app.routes.saude_familiar import bp as saude_familiar_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
     app.register_blueprint(contato_bp)
     app.register_blueprint(composicao_familiar_bp)
     app.register_blueprint(condicoes_moradia_bp)
+    app.register_blueprint(saude_familiar_bp)

--- a/app/routes/saude_familiar.py
+++ b/app/routes/saude_familiar.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.saude_familiar import SaudeFamiliar
+from app.schemas.saude_familiar import SaudeFamiliarSchema
+from app import db
+
+bp = Blueprint("saude_familiar", __name__, url_prefix="/saude_familiar")
+
+saude_schema = SaudeFamiliarSchema()
+saudes_schema = SaudeFamiliarSchema(many=True)
+
+@bp.route("", methods=["POST"])
+def criar_saude():
+    data = request.get_json()
+    try:
+        nova_saude = saude_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(nova_saude)
+    db.session.commit()
+    return saude_schema.jsonify(nova_saude), 201
+
+@bp.route("", methods=["GET"])
+def listar_saudes():
+    saudes = SaudeFamiliar.query.all()
+    return saudes_schema.jsonify(saudes), 200
+
+@bp.route("/<int:saude_id>", methods=["GET"])
+def obter_saude(saude_id):
+    saude = db.session.get(SaudeFamiliar, saude_id)
+    if not saude:
+        return jsonify({"mensagem": "Saude familiar não encontrada"}), 404
+    return saude_schema.jsonify(saude)
+
+@bp.route("/<int:saude_id>", methods=["PUT"])
+def atualizar_saude(saude_id):
+    saude = db.session.get(SaudeFamiliar, saude_id)
+    if not saude:
+        return jsonify({"mensagem": "Saude familiar não encontrada"}), 404
+
+    data = request.get_json()
+    saude = saude_schema.load(data, instance=saude, partial=True)
+
+    db.session.commit()
+    return saude_schema.jsonify(saude)
+
+@bp.route("/<int:saude_id>", methods=["DELETE"])
+def deletar_saude(saude_id):
+    saude = db.session.get(SaudeFamiliar, saude_id)
+    if not saude:
+        return jsonify({"mensagem": "Saude familiar não encontrada"}), 404
+
+    db.session.delete(saude)
+    db.session.commit()
+    return jsonify({"mensagem": "Saude familiar deletada com sucesso"}), 200

--- a/app/schemas/saude_familiar.py
+++ b/app/schemas/saude_familiar.py
@@ -1,0 +1,17 @@
+from app import ma
+from app.models.saude_familiar import SaudeFamiliar
+
+class SaudeFamiliarSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = SaudeFamiliar
+        load_instance = True
+
+    saude_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    tem_doenca_cronica = ma.auto_field()
+    descricao_doenca_cronica = ma.auto_field()
+    usa_medicacao_continua = ma.auto_field()
+    descricao_medicacao = ma.auto_field()
+    tem_deficiencia = ma.auto_field()
+    descricao_deficiencia = ma.auto_field()
+    recebe_bpc = ma.auto_field()

--- a/tests/test_saude_familiar_routes.py
+++ b/tests/test_saude_familiar_routes.py
@@ -1,0 +1,94 @@
+import pytest
+from app import create_app
+
+_familia_id_saude = None
+_saude_id_gerado = None
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+def test_post_saude_familiar(client):
+    global _familia_id_saude, _saude_id_gerado
+
+    payload_familia = {
+        "nome_responsavel": "Teste Pytest",
+        "data_nascimento": "1990-01-01",
+        "genero": "Masculino",
+        "genero_autodeclarado": "Homem",
+        "estado_civil": "Solteiro",
+        "rg": "999999999",
+        "cpf": "794.134.270-70",
+        "autoriza_uso_imagem": True,
+    }
+
+    response = client.post("/familias", json=payload_familia)
+    assert response.status_code == 201
+    data = response.get_json()
+    _familia_id_saude = data["familia_id"]
+
+    payload = {
+        "familia_id": _familia_id_saude,
+        "tem_doenca_cronica": True,
+        "descricao_doenca_cronica": "Diabetes",
+        "usa_medicacao_continua": True,
+        "descricao_medicacao": "Insulina",
+        "tem_deficiencia": False,
+        "descricao_deficiencia": None,
+        "recebe_bpc": False,
+    }
+
+    response = client.post("/saude_familiar", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "saude_id" in data
+    _saude_id_gerado = data["saude_id"]
+
+
+def test_get_saudes(client):
+    response = client.get("/saude_familiar")
+    assert response.status_code == 200
+
+
+def test_get_saude_por_id(client):
+    global _saude_id_gerado
+    response = client.get(f"/saude_familiar/{_saude_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["saude_id"] == _saude_id_gerado
+
+
+def test_put_saude(client):
+    global _saude_id_gerado
+    update_payload = {"recebe_bpc": True}
+    response = client.put(f"/saude_familiar/{_saude_id_gerado}", json=update_payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["recebe_bpc"] is True
+
+
+def test_delete_saude(client):
+    global _saude_id_gerado
+    response = client.delete(f"/saude_familiar/{_saude_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["mensagem"] == "Saude familiar deletada com sucesso"
+
+
+def test_get_saude_depois_do_delete(client):
+    global _saude_id_gerado
+    response = client.get(f"/saude_familiar/{_saude_id_gerado}")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["mensagem"] == "Saude familiar não encontrada"
+
+
+def test_cleanup_familia(client):
+    global _familia_id_saude
+    if _familia_id_saude:
+        client.delete(f"/familias/{_familia_id_saude}")


### PR DESCRIPTION
## Summary
- add `SaudeFamiliar` model, schema and routes
- register saude_familiar blueprint
- add pytest suite for saude_familiar CRUD

## Testing
- `pytest -q` *(fails: ODBC Driver for SQL Server missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846b427b79c8320bef3992d79922cd7