### PR TITLE
Implement Endereco CRUD

### DIFF
--- a/app/models/endereco.py
+++ b/app/models/endereco.py
@@ -1,0 +1,16 @@
+from app import db
+
+class Endereco(db.Model):
+    __tablename__ = "enderecos"
+
+    endereco_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    cep = db.Column(db.String(10))
+    preenchimento_manual = db.Column(db.Boolean)
+    logradouro = db.Column(db.String(150))
+    numero = db.Column(db.String(10))
+    complemento = db.Column(db.String(50))
+    bairro = db.Column(db.String(100))
+    cidade = db.Column(db.String(100))
+    estado = db.Column(db.String(100))
+    ponto_referencia = db.Column(db.String(200))

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -2,9 +2,11 @@ from app.routes.familia import bp as familia_bp
 from app.routes.contato import bp as contato_bp
 from app.routes.composicao_familiar import bp as composicao_familiar_bp
 from app.routes.condicoes_moradia import bp as condicoes_moradia_bp
+from app.routes.endereco import bp as endereco_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
     app.register_blueprint(contato_bp)
     app.register_blueprint(composicao_familiar_bp)
     app.register_blueprint(condicoes_moradia_bp)
+    app.register_blueprint(endereco_bp)

--- a/app/routes/endereco.py
+++ b/app/routes/endereco.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.endereco import Endereco
+from app.schemas.endereco import EnderecoSchema
+from app import db
+
+bp = Blueprint("enderecos", __name__, url_prefix="/enderecos")
+
+endereco_schema = EnderecoSchema()
+enderecos_schema = EnderecoSchema(many=True)
+
+@bp.route("", methods=["POST"])
+def criar_endereco():
+    data = request.get_json()
+    try:
+        novo_endereco = endereco_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(novo_endereco)
+    db.session.commit()
+    return endereco_schema.jsonify(novo_endereco), 201
+
+@bp.route("", methods=["GET"])
+def listar_enderecos():
+    enderecos = Endereco.query.all()
+    return enderecos_schema.jsonify(enderecos), 200
+
+@bp.route("/<int:endereco_id>", methods=["GET"])
+def obter_endereco(endereco_id):
+    endereco = db.session.get(Endereco, endereco_id)
+    if not endereco:
+        return jsonify({"mensagem": "Endereço não encontrado"}), 404
+    return endereco_schema.jsonify(endereco)
+
+@bp.route("/<int:endereco_id>", methods=["PUT"])
+def atualizar_endereco(endereco_id):
+    endereco = db.session.get(Endereco, endereco_id)
+    if not endereco:
+        return jsonify({"mensagem": "Endereço não encontrado"}), 404
+
+    data = request.get_json()
+    endereco = endereco_schema.load(data, instance=endereco, partial=True)
+
+    db.session.commit()
+    return endereco_schema.jsonify(endereco)
+
+@bp.route("/<int:endereco_id>", methods=["DELETE"])
+def deletar_endereco(endereco_id):
+    endereco = db.session.get(Endereco, endereco_id)
+    if not endereco:
+        return jsonify({"mensagem": "Endereço não encontrado"}), 404
+
+    db.session.delete(endereco)
+    db.session.commit()
+    return jsonify({"mensagem": "Endereço deletado com sucesso"}), 200

--- a/app/schemas/endereco.py
+++ b/app/schemas/endereco.py
@@ -1,0 +1,19 @@
+from app import ma
+from app.models.endereco import Endereco
+
+class EnderecoSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = Endereco
+        load_instance = True
+
+    endereco_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    cep = ma.auto_field()
+    preenchimento_manual = ma.auto_field()
+    logradouro = ma.auto_field()
+    numero = ma.auto_field()
+    complemento = ma.auto_field()
+    bairro = ma.auto_field()
+    cidade = ma.auto_field()
+    estado = ma.auto_field()
+    ponto_referencia = ma.auto_field()

--- a/tests/test_endereco_routes.py
+++ b/tests/test_endereco_routes.py
@@ -1,0 +1,98 @@
+import pytest
+from app import create_app
+
+_familia_id_endereco = None
+_endereco_id_gerado = None
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def test_post_endereco(client):
+    global _familia_id_endereco, _endereco_id_gerado
+
+    payload_familia = {
+        "nome_responsavel": "Teste Pytest",
+        "data_nascimento": "1990-01-01",
+        "genero": "Masculino",
+        "genero_autodeclarado": "Homem",
+        "estado_civil": "Solteiro",
+        "rg": "999999999",
+        "cpf": "794.134.270-70",
+        "autoriza_uso_imagem": True,
+    }
+
+    response = client.post("/familias", json=payload_familia)
+    assert response.status_code == 201
+    data = response.get_json()
+    _familia_id_endereco = data["familia_id"]
+
+    payload = {
+        "familia_id": _familia_id_endereco,
+        "cep": "12345678",
+        "preenchimento_manual": False,
+        "logradouro": "Rua Teste",
+        "numero": "100",
+        "complemento": "Ap 1",
+        "bairro": "Centro",
+        "cidade": "Cidade Teste",
+        "estado": "Estado Teste",
+        "ponto_referencia": "Perto de algo",
+    }
+
+    response = client.post("/enderecos", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "endereco_id" in data
+    _endereco_id_gerado = data["endereco_id"]
+
+
+def test_get_enderecos(client):
+    response = client.get("/enderecos")
+    assert response.status_code == 200
+
+
+def test_get_endereco_por_id(client):
+    global _endereco_id_gerado
+    response = client.get(f"/enderecos/{_endereco_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["endereco_id"] == _endereco_id_gerado
+
+
+def test_put_endereco(client):
+    global _endereco_id_gerado
+    update_payload = {"numero": "200"}
+    response = client.put(f"/enderecos/{_endereco_id_gerado}", json=update_payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["numero"] == "200"
+
+
+def test_delete_endereco(client):
+    global _endereco_id_gerado
+    response = client.delete(f"/enderecos/{_endereco_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["mensagem"] == "Endereço deletado com sucesso"
+
+
+def test_get_endereco_depois_do_delete(client):
+    global _endereco_id_gerado
+    response = client.get(f"/enderecos/{_endereco_id_gerado}")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["mensagem"] == "Endereço não encontrado"
+
+
+def test_cleanup_familia(client):
+    global _familia_id_endereco
+    if _familia_id_endereco:
+        client.delete(f"/familias/{_familia_id_endereco}")


### PR DESCRIPTION
## Summary
- add Endereco SQLAlchemy model
- create Marshmallow schema for addresses
- expose CRUD endpoints via `enderecos` blueprint
- register new blueprint
- include pytest coverage for Endereco routes

## Testing
- `pytest -q` *(fails: ODBC driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846b3b717388320ad9729c837c73bdb