### PR TITLE
Implement emprego_provedor CRUD

### DIFF
--- a/app/models/emprego_provedor.py
+++ b/app/models/emprego_provedor.py
@@ -1,0 +1,15 @@
+from app import db
+
+class EmpregoProvedor(db.Model):
+    __tablename__ = "emprego_provedor"
+
+    emprego_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    relacao_provedor_familia = db.Column(db.String(100))
+    descricao_provedor_externo = db.Column(db.Text)
+    situacao_emprego = db.Column(db.String(50))
+    descricao_situacao_emprego_outro = db.Column(db.Text)
+    profissao_provedor = db.Column(db.String(100))
+    experiencia_profissional = db.Column(db.Text)
+    formacao_profissional = db.Column(db.Text)
+    habilidades_relevantes = db.Column(db.Text)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -6,6 +6,7 @@ from app.routes.renda_familiar import bp as renda_familiar_bp
 from app.routes.endereco import bp as endereco_bp
 from app.routes.saude_familiar import bp as saude_familiar_bp
 from app.routes.educacao_entrevistado import bp as educacao_entrevistado_bp
+from app.routes.emprego_provedor import bp as emprego_provedor_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
@@ -16,3 +17,4 @@ def register_routes(app):
     app.register_blueprint(endereco_bp)
     app.register_blueprint(saude_familiar_bp)
     app.register_blueprint(educacao_entrevistado_bp)
+    app.register_blueprint(emprego_provedor_bp)

--- a/app/routes/emprego_provedor.py
+++ b/app/routes/emprego_provedor.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.emprego_provedor import EmpregoProvedor
+from app.schemas.emprego_provedor import EmpregoProvedorSchema
+from app import db
+
+bp = Blueprint("emprego_provedor", __name__, url_prefix="/emprego_provedor")
+
+emprego_schema = EmpregoProvedorSchema()
+empregos_schema = EmpregoProvedorSchema(many=True)
+
+@bp.route("", methods=["POST"])
+def criar_emprego():
+    data = request.get_json()
+    try:
+        novo_emprego = emprego_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(novo_emprego)
+    db.session.commit()
+    return emprego_schema.jsonify(novo_emprego), 201
+
+@bp.route("", methods=["GET"])
+def listar_empregos():
+    empregos = EmpregoProvedor.query.all()
+    return empregos_schema.jsonify(empregos), 200
+
+@bp.route("/<int:emprego_id>", methods=["GET"])
+def obter_emprego(emprego_id):
+    emprego = db.session.get(EmpregoProvedor, emprego_id)
+    if not emprego:
+        return jsonify({"mensagem": "Emprego provedor não encontrado"}), 404
+    return emprego_schema.jsonify(emprego)
+
+@bp.route("/<int:emprego_id>", methods=["PUT"])
+def atualizar_emprego(emprego_id):
+    emprego = db.session.get(EmpregoProvedor, emprego_id)
+    if not emprego:
+        return jsonify({"mensagem": "Emprego provedor não encontrado"}), 404
+
+    data = request.get_json()
+    emprego = emprego_schema.load(data, instance=emprego, partial=True)
+
+    db.session.commit()
+    return emprego_schema.jsonify(emprego)
+
+@bp.route("/<int:emprego_id>", methods=["DELETE"])
+def deletar_emprego(emprego_id):
+    emprego = db.session.get(EmpregoProvedor, emprego_id)
+    if not emprego:
+        return jsonify({"mensagem": "Emprego provedor não encontrado"}), 404
+
+    db.session.delete(emprego)
+    db.session.commit()
+    return jsonify({"mensagem": "Emprego provedor deletado com sucesso"}), 200

--- a/app/schemas/emprego_provedor.py
+++ b/app/schemas/emprego_provedor.py
@@ -1,0 +1,18 @@
+from app import ma
+from app.models.emprego_provedor import EmpregoProvedor
+
+class EmpregoProvedorSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = EmpregoProvedor
+        load_instance = True
+
+    emprego_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    relacao_provedor_familia = ma.auto_field()
+    descricao_provedor_externo = ma.auto_field()
+    situacao_emprego = ma.auto_field()
+    descricao_situacao_emprego_outro = ma.auto_field()
+    profissao_provedor = ma.auto_field()
+    experiencia_profissional = ma.auto_field()
+    formacao_profissional = ma.auto_field()
+    habilidades_relevantes = ma.auto_field()

--- a/tests/test_emprego_provedor_routes.py
+++ b/tests/test_emprego_provedor_routes.py
@@ -1,0 +1,97 @@
+import pytest
+from app import create_app
+
+_familia_id_emprego = None
+_emprego_id_gerado = None
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def test_post_emprego_provedor(client):
+    global _familia_id_emprego, _emprego_id_gerado
+
+    payload_familia = {
+        "nome_responsavel": "Teste Pytest",
+        "data_nascimento": "1990-01-01",
+        "genero": "Masculino",
+        "genero_autodeclarado": "Homem",
+        "estado_civil": "Solteiro",
+        "rg": "999999999",
+        "cpf": "794.134.270-70",
+        "autoriza_uso_imagem": True,
+    }
+
+    response = client.post("/familias", json=payload_familia)
+    assert response.status_code == 201
+    data = response.get_json()
+    _familia_id_emprego = data["familia_id"]
+
+    payload = {
+        "familia_id": _familia_id_emprego,
+        "relacao_provedor_familia": "Pai",
+        "descricao_provedor_externo": "Emprego formal",
+        "situacao_emprego": "Ativo",
+        "descricao_situacao_emprego_outro": "",
+        "profissao_provedor": "Pedreiro",
+        "experiencia_profissional": "5 anos",
+        "formacao_profissional": "Ensino Fundamental",
+        "habilidades_relevantes": "Alvenaria",
+    }
+
+    response = client.post("/emprego_provedor", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "emprego_id" in data
+    _emprego_id_gerado = data["emprego_id"]
+
+
+def test_get_empregos(client):
+    response = client.get("/emprego_provedor")
+    assert response.status_code == 200
+
+
+def test_get_emprego_por_id(client):
+    global _emprego_id_gerado
+    response = client.get(f"/emprego_provedor/{_emprego_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["emprego_id"] == _emprego_id_gerado
+
+
+def test_put_emprego(client):
+    global _emprego_id_gerado
+    update_payload = {"situacao_emprego": "Desempregado"}
+    response = client.put(f"/emprego_provedor/{_emprego_id_gerado}", json=update_payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["situacao_emprego"] == "Desempregado"
+
+
+def test_delete_emprego(client):
+    global _emprego_id_gerado
+    response = client.delete(f"/emprego_provedor/{_emprego_id_gerado}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["mensagem"] == "Emprego provedor deletado com sucesso"
+
+
+def test_get_emprego_depois_do_delete(client):
+    global _emprego_id_gerado
+    response = client.get(f"/emprego_provedor/{_emprego_id_gerado}")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data["mensagem"] == "Emprego provedor não encontrado"
+
+
+def test_cleanup_familia(client):
+    global _familia_id_emprego
+    if _familia_id_emprego:
+        client.delete(f"/familias/{_familia_id_emprego}")


### PR DESCRIPTION
## Summary
- add EmpregoProvedor model
- add EmpregoProvedor schema
- create emprego_provedor routes with CRUD endpoints
- register new blueprint
- add tests for emprego_provedor

## Testing
- `pytest -q` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b7ac93e88320a162186edff8b638