### PR TITLE
Add log timestamp column

### DIFF
--- a/app/models/composicao_familiar.py
+++ b/app/models/composicao_familiar.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class ComposicaoFamiliar(db.Model):
     __tablename__ = "composicao_familiar"
@@ -13,3 +14,9 @@ class ComposicaoFamiliar(db.Model):
     quantidade_idosos = db.Column(db.Integer)
     tem_menores_na_escola = db.Column(db.Boolean)
     motivo_ausencia_escola = db.Column(db.Text)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/condicoes_moradia.py
+++ b/app/models/condicoes_moradia.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 
 class CondicaoMoradia(db.Model):
@@ -16,3 +17,9 @@ class CondicaoMoradia(db.Model):
     quantidade_camas = db.Column(db.Integer)
     quantidade_tvs = db.Column(db.Integer)
     quantidade_ventiladores = db.Column(db.Integer)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/contato.py
+++ b/app/models/contato.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 
 class Contato(db.Model):
@@ -13,3 +14,9 @@ class Contato(db.Model):
     telefone_alternativo_whatsapp = db.Column(db.Boolean)
     telefone_alternativo_nome_contato = db.Column(db.String(100))
     email_responsavel = db.Column(db.String(100))
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/educacao_entrevistado.py
+++ b/app/models/educacao_entrevistado.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class EducacaoEntrevistado(db.Model):
     __tablename__ = "educacao_entrevistado"
@@ -8,3 +9,9 @@ class EducacaoEntrevistado(db.Model):
     nivel_escolaridade = db.Column(db.String(100))
     estuda_atualmente = db.Column(db.String(3))
     curso_ou_serie_atual = db.Column(db.Text)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/emprego_provedor.py
+++ b/app/models/emprego_provedor.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class EmpregoProvedor(db.Model):
     __tablename__ = "emprego_provedor"
@@ -13,3 +14,9 @@ class EmpregoProvedor(db.Model):
     experiencia_profissional = db.Column(db.Text)
     formacao_profissional = db.Column(db.Text)
     habilidades_relevantes = db.Column(db.Text)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/endereco.py
+++ b/app/models/endereco.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class Endereco(db.Model):
     __tablename__ = "enderecos"
@@ -14,3 +15,9 @@ class Endereco(db.Model):
     cidade = db.Column(db.String(100))
     estado = db.Column(db.String(100))
     ponto_referencia = db.Column(db.String(200))
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/familia.py
+++ b/app/models/familia.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class Familia(db.Model):
     __tablename__ = 'familias'
@@ -12,3 +13,9 @@ class Familia(db.Model):
     rg = db.Column(db.String(20))
     cpf = db.Column(db.String(14))
     autoriza_uso_imagem = db.Column(db.Boolean)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/renda_familiar.py
+++ b/app/models/renda_familiar.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class RendaFamiliar(db.Model):
     __tablename__ = "renda_familiar"
@@ -25,3 +26,9 @@ class RendaFamiliar(db.Model):
     renda_total_familiar = db.Column(db.Numeric(10, 2))
     gastos_totais = db.Column(db.Numeric(10, 2))
     saldo_mensal = db.Column(db.Numeric(10, 2))
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/models/saude_familiar.py
+++ b/app/models/saude_familiar.py
@@ -1,4 +1,5 @@
 from app import db
+from datetime import datetime
 
 class SaudeFamiliar(db.Model):
     __tablename__ = "saude_familiar"
@@ -12,3 +13,9 @@ class SaudeFamiliar(db.Model):
     tem_deficiencia = db.Column(db.Boolean)
     descricao_deficiencia = db.Column(db.Text)
     recebe_bpc = db.Column(db.Boolean)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )

--- a/app/schemas/composicao_familiar.py
+++ b/app/schemas/composicao_familiar.py
@@ -16,3 +16,4 @@ class ComposicaoFamiliarSchema(ma.SQLAlchemySchema):
     quantidade_idosos = ma.auto_field()
     tem_menores_na_escola = ma.auto_field()
     motivo_ausencia_escola = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/condicoes_moradia.py
+++ b/app/schemas/condicoes_moradia.py
@@ -19,3 +19,4 @@ class CondicaoMoradiaSchema(ma.SQLAlchemySchema):
     quantidade_camas = ma.auto_field()
     quantidade_tvs = ma.auto_field()
     quantidade_ventiladores = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/contato.py
+++ b/app/schemas/contato.py
@@ -16,3 +16,4 @@ class ContatoSchema(ma.SQLAlchemySchema):
     telefone_alternativo_whatsapp = ma.auto_field()
     telefone_alternativo_nome_contato = ma.auto_field()
     email_responsavel = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/educacao_entrevistado.py
+++ b/app/schemas/educacao_entrevistado.py
@@ -12,3 +12,4 @@ class EducacaoEntrevistadoSchema(ma.SQLAlchemySchema):
     nivel_escolaridade = ma.auto_field()
     estuda_atualmente = ma.auto_field()
     curso_ou_serie_atual = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/emprego_provedor.py
+++ b/app/schemas/emprego_provedor.py
@@ -16,3 +16,4 @@ class EmpregoProvedorSchema(ma.SQLAlchemySchema):
     experiencia_profissional = ma.auto_field()
     formacao_profissional = ma.auto_field()
     habilidades_relevantes = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/endereco.py
+++ b/app/schemas/endereco.py
@@ -17,3 +17,4 @@ class EnderecoSchema(ma.SQLAlchemySchema):
     cidade = ma.auto_field()
     estado = ma.auto_field()
     ponto_referencia = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/familia.py
+++ b/app/schemas/familia.py
@@ -17,6 +17,7 @@ class FamiliaSchema(ma.SQLAlchemySchema):
     rg = ma.auto_field()
     cpf = ma.auto_field()
     autoriza_uso_imagem = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)
 
     @validates("cpf")
     # Recebe **kwargs para compatibilidade com marshmallow>=4,

--- a/app/schemas/renda_familiar.py
+++ b/app/schemas/renda_familiar.py
@@ -28,3 +28,4 @@ class RendaFamiliarSchema(ma.SQLAlchemySchema):
     renda_total_familiar = ma.auto_field()
     gastos_totais = ma.auto_field()
     saldo_mensal = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/saude_familiar.py
+++ b/app/schemas/saude_familiar.py
@@ -15,3 +15,4 @@ class SaudeFamiliarSchema(ma.SQLAlchemySchema):
     tem_deficiencia = ma.auto_field()
     descricao_deficiencia = ma.auto_field()
     recebe_bpc = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,7 @@
+from app import create_app, db
+
+app = create_app()
+
+if __name__ == "__main__":
+    with app.app_context():
+        db.create_all()


### PR DESCRIPTION
## Summary
- add `data_hora_log_utc` field to all models with automatic UTC timestamps
- expose the new column via schemas as dump-only
- provide `manage.py` helper to recreate database tables

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_6846e16bcac483209190cf5a33acecfb