### PR TITLE
fix utcnow warning

### DIFF
--- a/app/models/composicao_familiar.py
+++ b/app/models/composicao_familiar.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class ComposicaoFamiliar(db.Model):
     __tablename__ = "composicao_familiar"
@@ -16,7 +16,7 @@ class ComposicaoFamiliar(db.Model):
     motivo_ausencia_escola = db.Column(db.Text)
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/condicoes_moradia.py
+++ b/app/models/condicoes_moradia.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class CondicaoMoradia(db.Model):
@@ -19,7 +19,7 @@ class CondicaoMoradia(db.Model):
     quantidade_ventiladores = db.Column(db.Integer)
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/contato.py
+++ b/app/models/contato.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Contato(db.Model):
@@ -16,7 +16,7 @@ class Contato(db.Model):
     email_responsavel = db.Column(db.String(100))
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/educacao_entrevistado.py
+++ b/app/models/educacao_entrevistado.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class EducacaoEntrevistado(db.Model):
     __tablename__ = "educacao_entrevistado"
@@ -11,7 +11,7 @@ class EducacaoEntrevistado(db.Model):
     curso_ou_serie_atual = db.Column(db.Text)
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/emprego_provedor.py
+++ b/app/models/emprego_provedor.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class EmpregoProvedor(db.Model):
     __tablename__ = "emprego_provedor"
@@ -16,7 +16,7 @@ class EmpregoProvedor(db.Model):
     habilidades_relevantes = db.Column(db.Text)
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/endereco.py
+++ b/app/models/endereco.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class Endereco(db.Model):
     __tablename__ = "enderecos"
@@ -17,7 +17,7 @@ class Endereco(db.Model):
     ponto_referencia = db.Column(db.String(200))
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/familia.py
+++ b/app/models/familia.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class Familia(db.Model):
     __tablename__ = 'familias'
@@ -15,7 +15,7 @@ class Familia(db.Model):
     autoriza_uso_imagem = db.Column(db.Boolean)
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/renda_familiar.py
+++ b/app/models/renda_familiar.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class RendaFamiliar(db.Model):
     __tablename__ = "renda_familiar"
@@ -28,7 +28,7 @@ class RendaFamiliar(db.Model):
     saldo_mensal = db.Column(db.Numeric(10, 2))
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )

--- a/app/models/saude_familiar.py
+++ b/app/models/saude_familiar.py
@@ -1,5 +1,5 @@
 from app import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 class SaudeFamiliar(db.Model):
     __tablename__ = "saude_familiar"
@@ -15,7 +15,7 @@ class SaudeFamiliar(db.Model):
     recebe_bpc = db.Column(db.Boolean)
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )


### PR DESCRIPTION
## Summary
- use timezone-aware datetime now for model timestamps

## Testing
- `pytest -q` *(fails: Can't open lib 'ODBC Driver 17 for SQL Server')*

------
https://chatgpt.com/codex/tasks/task_e_6846e6baf85c8320ad2097a17465b7be