### PR TITLE
Implement family schema validations

### DIFF
--- a/tests/test_composicao_familiar_routes.py
+++ b/tests/test_composicao_familiar_routes.py
@@ -22,7 +22,6 @@ def test_post_composicao_familiar(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_condicoes_moradia_routes.py
+++ b/tests/test_condicoes_moradia_routes.py
@@ -22,7 +22,6 @@ def test_post_condicao_moradia(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_contato_routes.py
+++ b/tests/test_contato_routes.py
@@ -22,7 +22,6 @@ def test_post_contato(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_educacao_entrevistado_routes.py
+++ b/tests/test_educacao_entrevistado_routes.py
@@ -22,7 +22,6 @@ def test_post_educacao_entrevistado(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_emprego_provedor_routes.py
+++ b/tests/test_emprego_provedor_routes.py
@@ -22,7 +22,6 @@ def test_post_emprego_provedor(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_endereco_routes.py
+++ b/tests/test_endereco_routes.py
@@ -22,7 +22,6 @@ def test_post_endereco(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_familia_routes.py
+++ b/tests/test_familia_routes.py
@@ -20,7 +20,6 @@ def test_post_familia(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",
@@ -83,7 +82,6 @@ def test_post_familia_cpf_invalido(client):
         "nome_responsavel": "CPF Inválido",
         "data_nascimento": "1990-01-01",
         "genero": "Feminino",
-        "genero_autodeclarado": "Mulher",
         "estado_civil": "Solteira",
         "rg": "123456789",
         "cpf": "123.456.789-00",  # CPF inválido de propósito

--- a/tests/test_integracao_cadastro_completo.py
+++ b/tests/test_integracao_cadastro_completo.py
@@ -17,7 +17,6 @@ def test_cadastro_completo(client):
         "nome_responsavel": "Ana de Teste",
         "data_nascimento": "1985-05-10",
         "genero": "Feminino",
-        "genero_autodeclarado": "",
         "estado_civil": "Casada",
         "rg": "123456789",
         "cpf": "829.438.580-80",

--- a/tests/test_renda_familiar_routes.py
+++ b/tests/test_renda_familiar_routes.py
@@ -23,7 +23,6 @@ def test_post_renda_familiar(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",

--- a/tests/test_saude_familiar_routes.py
+++ b/tests/test_saude_familiar_routes.py
@@ -20,7 +20,6 @@ def test_post_saude_familiar(client):
         "nome_responsavel": "Teste Pytest",
         "data_nascimento": "1990-01-01",
         "genero": "Masculino",
-        "genero_autodeclarado": "Homem",
         "estado_civil": "Solteiro",
         "rg": "999999999",
         "cpf": "794.134.270-70",


### PR DESCRIPTION
## Summary
- validate `estado_civil` against allowed values
- enforce `genero_autodeclarado` only when `genero` is `"Outro"`
- update tests to align with new schema rules

## Testing
- `pytest -q` *(fails: pyodbc driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846fc5807ec83209426eaf5a43dd291