### PR TITLE
Add atendimento familia step1 page

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,5 +9,11 @@ def home():
     return render_template("index.html")
 
 
+@app.route("/atendimento/etapa1")
+def atendimento_etapa1():
+    """Exibe a primeira etapa do atendimento à família."""
+    return render_template("atendimento/etapa1_dados_pessoais.html")
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/app/static/js/etapa1_dados_pessoais.js
+++ b/app/static/js/etapa1_dados_pessoais.js
@@ -1,0 +1,62 @@
+// JS para etapa 1 - dados pessoais
+function validarCPF(cpf) {
+    cpf = cpf.replace(/\D/g, '');
+    if (cpf.length !== 11 || /^(\d)\1{10}$/.test(cpf)) return false;
+    let soma = 0;
+    for (let i = 0; i < 9; i++) soma += parseInt(cpf.charAt(i)) * (10 - i);
+    let digito1 = 11 - (soma % 11);
+    if (digito1 > 9) digito1 = 0;
+    if (digito1 !== parseInt(cpf.charAt(9))) return false;
+    soma = 0;
+    for (let i = 0; i < 10; i++) soma += parseInt(cpf.charAt(i)) * (11 - i);
+    let digito2 = 11 - (soma % 11);
+    if (digito2 > 9) digito2 = 0;
+    if (digito2 !== parseInt(cpf.charAt(10))) return false;
+    return true;
+}
+
+function aplicarMascaraCPF(valor) {
+    let v = valor.replace(/\D/g, '').slice(0, 11);
+    if (v.length > 9) v = v.replace(/(\d{3})(\d{3})(\d{3})(\d{1,2}).*/, '$1.$2.$3-$4');
+    else if (v.length > 6) v = v.replace(/(\d{3})(\d{3})(\d+)/, '$1.$2.$3');
+    else if (v.length > 3) v = v.replace(/(\d{3})(\d+)/, '$1.$2');
+    return v;
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const dataInput = document.getElementById('data_nascimento');
+    if (dataInput) {
+        const hoje = new Date();
+        const ano = hoje.getFullYear() - 10;
+        const dataPadrao = new Date(ano, hoje.getMonth(), hoje.getDate());
+        dataInput.value = dataPadrao.toISOString().split('T')[0];
+    }
+
+    const generoSelect = document.getElementById('genero');
+    const generoOutroContainer = document.getElementById('genero_autodeclarado_container');
+    generoSelect.addEventListener('change', function() {
+        if (this.value === 'Outro') {
+            generoOutroContainer.classList.remove('d-none');
+        } else {
+            generoOutroContainer.classList.add('d-none');
+            document.getElementById('genero_autodeclarado').value = '';
+        }
+    });
+
+    const cpfInput = document.getElementById('cpf');
+    cpfInput.addEventListener('input', function(e) {
+        this.value = aplicarMascaraCPF(this.value);
+    });
+    cpfInput.addEventListener('blur', function() {
+        const valido = validarCPF(this.value);
+        if (!valido && this.value !== '') {
+            alert('CPF inválido');
+            this.focus();
+        }
+    });
+
+    document.getElementById('btnProxima').addEventListener('click', function() {
+        const form = document.getElementById('formEtapa1');
+        console.log('Dados do formulário etapa 1:', Object.fromEntries(new FormData(form).entries()));
+    });
+});

--- a/app/templates/atendimento/etapa1_dados_pessoais.html
+++ b/app/templates/atendimento/etapa1_dados_pessoais.html
@@ -1,0 +1,66 @@
+{% extends 'base.html' %}
+{% block title %}Atendimento à Família - Etapa 1{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Etapa 1 de 9 - Informações pessoais do(a) entrevistado(a)</h2>
+<form id="formEtapa1">
+    <div class="mb-3">
+        <label for="nome_responsavel" class="form-label">Nome completo do responsável pela família</label>
+        <input type="text" class="form-control" id="nome_responsavel" name="nome_responsavel" required>
+    </div>
+    <div class="mb-3">
+        <label for="data_nascimento" class="form-label">Data de nascimento</label>
+        <input type="date" class="form-control" id="data_nascimento" name="data_nascimento" required>
+    </div>
+    <div class="mb-3">
+        <label for="genero" class="form-label">Gênero</label>
+        <select class="form-select" id="genero" name="genero" required>
+            <option value="" selected disabled>Selecione</option>
+            <option value="Masculino">Masculino</option>
+            <option value="Feminino">Feminino</option>
+            <option value="Outro">Outro</option>
+        </select>
+    </div>
+    <div class="mb-3 d-none" id="genero_autodeclarado_container">
+        <label for="genero_autodeclarado" class="form-label">Se outro, como a pessoa se identifica?</label>
+        <input type="text" class="form-control" id="genero_autodeclarado" name="genero_autodeclarado">
+    </div>
+    <div class="mb-3">
+        <label for="estado_civil" class="form-label">Estado civil</label>
+        <select class="form-select" id="estado_civil" name="estado_civil" required>
+            <option value="" selected disabled>Selecione</option>
+            <option value="Solteira(o)">Solteira(o)</option>
+            <option value="Casada(o)">Casada(o)</option>
+            <option value="Divorciada(o)">Divorciada(o)</option>
+            <option value="Viúva(o)">Viúva(o)</option>
+            <option value="União Estável">União Estável</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="rg" class="form-label">Documento de identidade (RG)</label>
+        <input type="text" class="form-control" id="rg" name="rg">
+    </div>
+    <div class="mb-3">
+        <label for="cpf" class="form-label">CPF do responsável</label>
+        <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Autoriza o uso de imagem em registros e divulgações?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="autoriza_uso_imagem" id="autoriza_sim" value="Sim" required>
+                <label class="form-check-label" for="autoriza_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="autoriza_uso_imagem" id="autoriza_nao" value="Não">
+                <label class="form-check-label" for="autoriza_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="text-end">
+        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+    </div>
+</form>
+{% endblock %}
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/etapa1_dados_pessoais.js') }}"></script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,7 @@
         <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
             <ul class="navbar-nav align-items-center">
                 <li class="nav-item"><a class="nav-link" href="#">Cadastro inicial da família</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('atendimento_etapa1') }}">Atendimento à Família</a></li>
                 <li class="nav-item"><a class="nav-link" href="#">Entrevista para retirada da cesta</a></li>
                 <li class="nav-item"><a class="nav-link" href="#">Acompanhamento de Demandas</a></li>
             </ul>


### PR DESCRIPTION
## Summary
- add new menu item for Atendimento à Família
- create etapa1_dados_pessoais template with form
- add JavaScript for CPF mask, validation, gender toggle, and button action
- route new page in app.py

## Testing
- `pytest -q` *(fails: DBAPIError due to missing driver)*

------
https://chatgpt.com/codex/tasks/task_e_684703ac5568832081bd80a012d305c6