### PR TITLE
Improve CPF validation UX

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -100,9 +100,12 @@ body {
     color: #dc3545;
 }
 
-/* Estilo movido do cadastrar_familia.html */
+/* Feedback de validação do CPF */
 #cpf-feedback {
     display: none;
+}
+.is-invalid ~ #cpf-feedback {
+    display: block;
 }
 
 /* Footer */

--- a/app/static/js/etapa1_dados_pessoais.js
+++ b/app/static/js/etapa1_dados_pessoais.js
@@ -1,7 +1,8 @@
 // JS para etapa 1 - dados pessoais
 function validarCPF(cpf) {
     cpf = cpf.replace(/\D/g, '');
-    if (cpf.length !== 11 || /^(\d)\1{10}$/.test(cpf)) return false;
+    if (cpf === '' || /^(\d)\1{10}$/.test(cpf)) return true;
+    if (cpf.length !== 11) return false;
     let soma = 0;
     for (let i = 0; i < 9; i++) soma += parseInt(cpf.charAt(i)) * (10 - i);
     let digito1 = 11 - (soma % 11);
@@ -44,19 +45,40 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     const cpfInput = document.getElementById('cpf');
-    cpfInput.addEventListener('input', function(e) {
-        this.value = aplicarMascaraCPF(this.value);
-    });
-    cpfInput.addEventListener('blur', function() {
-        const valido = validarCPF(this.value);
-        if (!valido && this.value !== '') {
-            alert('CPF inválido');
-            this.focus();
+    const btnProxima = document.getElementById('btnProxima');
+    const form = document.getElementById('formEtapa1');
+    const requiredInputs = form.querySelectorAll('[required]');
+
+    function exibirValidacaoCPF() {
+        const valido = validarCPF(cpfInput.value);
+        if (!valido) {
+            cpfInput.classList.add('is-invalid');
+        } else {
+            cpfInput.classList.remove('is-invalid');
         }
+        return valido;
+    }
+
+    function atualizarEstadoBotao() {
+        const cpfOk = exibirValidacaoCPF();
+        btnProxima.disabled = !(cpfOk && form.checkValidity());
+    }
+
+    cpfInput.addEventListener('input', function() {
+        this.value = aplicarMascaraCPF(this.value);
+        atualizarEstadoBotao();
     });
 
-    document.getElementById('btnProxima').addEventListener('click', function() {
-        const form = document.getElementById('formEtapa1');
+    cpfInput.addEventListener('blur', exibirValidacaoCPF);
+
+    requiredInputs.forEach(function(el) {
+        el.addEventListener('input', atualizarEstadoBotao);
+        el.addEventListener('change', atualizarEstadoBotao);
+    });
+
+    atualizarEstadoBotao();
+
+    btnProxima.addEventListener('click', function() {
         console.log('Dados do formulário etapa 1:', Object.fromEntries(new FormData(form).entries()));
     });
 });

--- a/app/templates/atendimento/etapa1_dados_pessoais.html
+++ b/app/templates/atendimento/etapa1_dados_pessoais.html
@@ -42,6 +42,7 @@
     <div class="mb-3">
         <label for="cpf" class="form-label">CPF do responsável</label>
         <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00" required>
+        <div id="cpf-feedback" class="invalid-feedback">CPF inválido</div>
     </div>
     <div class="mb-3">
         <label class="form-label">Autoriza o uso de imagem em registros e divulgações?</label>
@@ -57,7 +58,7 @@
         </div>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" disabled>Próxima etapa</button>
     </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show CPF validation feedback below the field
- disable next button until CPF and required fields are valid
- allow empty or repeated-digit CPFs
- add CSS rule to show CPF feedback when invalid

## Testing
- `pytest -q` *(fails: ODBC Driver 17 for SQL Server missing)*

------
https://chatgpt.com/codex/tasks/task_e_684709480d708320926e9e4f7da516a3