### PR TITLE
Adapta data de nascimento para formato brasileiro

### DIFF
--- a/app/static/js/etapa1_dados_pessoais.js
+++ b/app/static/js/etapa1_dados_pessoais.js
@@ -30,7 +30,21 @@ document.addEventListener('DOMContentLoaded', function() {
         const hoje = new Date();
         const ano = hoje.getFullYear() - 10;
         const dataPadrao = new Date(ano, hoje.getMonth(), hoje.getDate());
-        dataInput.value = dataPadrao.toISOString().split('T')[0];
+
+        flatpickr.localize(flatpickr.l10ns.pt);
+        const fp = flatpickr(dataInput, {
+            dateFormat: 'Y-m-d',
+            altInput: true,
+            altFormat: 'd/m/Y',
+            altInputClass: 'form-control',
+            defaultDate: dataPadrao,
+            allowInput: true
+        });
+
+        const altInput = fp.altInput;
+        if (altInput) {
+            Inputmask({ alias: 'datetime', inputFormat: 'dd/mm/yyyy' }).mask(altInput);
+        }
     }
 
     const generoSelect = document.getElementById('genero');

--- a/app/templates/atendimento/etapa1_dados_pessoais.html
+++ b/app/templates/atendimento/etapa1_dados_pessoais.html
@@ -9,7 +9,7 @@
     </div>
     <div class="mb-3">
         <label for="data_nascimento" class="form-label">Data de nascimento</label>
-        <input type="date" class="form-control" id="data_nascimento" name="data_nascimento" required>
+        <input type="text" class="form-control" id="data_nascimento" name="data_nascimento" placeholder="dd/mm/aaaa" required>
     </div>
     <div class="mb-3">
         <label for="genero" class="form-label">Gênero</label>
@@ -62,6 +62,14 @@
     </div>
 </form>
 {% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+{% endblock %}
+
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
 <script src="{{ url_for('static', filename='js/etapa1_dados_pessoais.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- exibe a data de nascimento no padrão brasileiro
- integra Flatpickr com locale em português e mascara de entrada

## Testing
- `pytest -q` *(fails: sqlalchemy errors)*

------
https://chatgpt.com/codex/tasks/task_e_68470ba063688320a7267008f771a7a8