### PR TITLE
Add step 2 routing and navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,5 +15,11 @@ def atendimento_etapa1():
     return render_template("atendimento/etapa1_dados_pessoais.html")
 
 
+@app.route("/atendimento/etapa2")
+def atendimento_etapa2():
+    """Exibe a segunda etapa do atendimento à família."""
+    return render_template("atendimento/etapa2_endereco.html")
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/app/static/js/etapa1_dados_pessoais.js
+++ b/app/static/js/etapa1_dados_pessoais.js
@@ -106,5 +106,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     btnProxima.addEventListener('click', function() {
         console.log('Dados do formulário etapa 1:', Object.fromEntries(new FormData(form).entries()));
+        const nextUrl = btnProxima.getAttribute('data-next-url');
+        if (nextUrl) {
+            window.location.href = nextUrl;
+        }
     });
 });

--- a/app/static/js/etapa2_endereco.js
+++ b/app/static/js/etapa2_endereco.js
@@ -1,0 +1,85 @@
+// JS para etapa 2 - endereço da família
+
+document.addEventListener('DOMContentLoaded', function() {
+    const cepInput = document.getElementById('cep');
+    const manualCheckbox = document.getElementById('preenchimento_manual');
+    const cepFeedback = document.getElementById('cep-feedback');
+    const addressFields = ['logradouro', 'bairro', 'cidade', 'estado'];
+
+    function setAddressFieldsEnabled(enabled) {
+        addressFields.forEach(id => {
+            const field = document.getElementById(id);
+            if (field) {
+                field.disabled = !enabled;
+            }
+        });
+        if (enabled) {
+            const cidade = document.getElementById('cidade');
+            const estado = document.getElementById('estado');
+            if (cidade && !cidade.value) cidade.value = 'Campinas';
+            if (estado && !estado.value) estado.value = 'SP';
+        }
+    }
+
+    function clearAddressFields() {
+        addressFields.forEach(id => {
+            const field = document.getElementById(id);
+            if (field) field.value = '';
+        });
+    }
+
+    function showCepError() {
+        if (cepFeedback) {
+            cepFeedback.classList.remove('d-none');
+        }
+        clearAddressFields();
+    }
+
+    if (manualCheckbox) {
+        manualCheckbox.addEventListener('change', function() {
+            setAddressFieldsEnabled(this.checked);
+            if (!this.checked) {
+                cepFeedback.classList.add('d-none');
+            }
+        });
+        // inicial
+        setAddressFieldsEnabled(manualCheckbox.checked);
+    }
+
+    if (cepInput) {
+        Inputmask('99999-999').mask(cepInput);
+
+        cepInput.addEventListener('blur', function() {
+            const cep = cepInput.value.replace(/\D/g, '');
+            if (cep.length === 8 && !manualCheckbox.checked) {
+                fetch(`https://viacep.com.br/ws/${cep}/json/`)
+                    .then(resp => resp.json())
+                    .then(data => {
+                        if (!data.erro) {
+                            document.getElementById('logradouro').value = data.logradouro || '';
+                            document.getElementById('bairro').value = data.bairro || '';
+                            document.getElementById('cidade').value = data.localidade || '';
+                            document.getElementById('estado').value = data.uf || '';
+                            cepFeedback.classList.add('d-none');
+                            document.getElementById('numero').focus();
+                        } else {
+                            showCepError();
+                        }
+                    })
+                    .catch(() => {
+                        showCepError();
+                    });
+            } else if (cep.length > 0 && !manualCheckbox.checked) {
+                showCepError();
+            }
+        });
+    }
+
+    const btnProxima = document.getElementById('btnProxima');
+    const form = document.getElementById('formEtapa2');
+    if (btnProxima && form) {
+        btnProxima.addEventListener('click', function() {
+            console.log('Dados do formulário etapa 2:', Object.fromEntries(new FormData(form).entries()));
+        });
+    }
+});

--- a/app/templates/atendimento/etapa1_dados_pessoais.html
+++ b/app/templates/atendimento/etapa1_dados_pessoais.html
@@ -58,7 +58,7 @@
         </div>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima" disabled>Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" disabled data-next-url="{{ url_for('atendimento_etapa2') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa2_endereco.html
+++ b/app/templates/atendimento/etapa2_endereco.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% block title %}Atendimento à Família - Etapa 2{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Etapa 2 de 9 - Endereço da família</h2>
+<form id="formEtapa2" autocomplete="off">
+    <div class="mb-3 form-check">
+        <input class="form-check-input" type="checkbox" id="preenchimento_manual" name="preenchimento_manual">
+        <label class="form-check-label" for="preenchimento_manual">Preencher endereço manualmente?</label>
+    </div>
+    <div class="mb-3">
+        <label for="cep" class="form-label">CEP</label>
+        <input type="text" class="form-control" id="cep" name="cep" autocomplete="off">
+        <div id="cep-feedback" class="form-text text-danger d-none">Não foi possível encontrar o endereço. Se necessário, marque a opção de preenchimento manual.</div>
+    </div>
+    <div class="mb-3">
+        <label for="logradouro" class="form-label">Rua / Avenida / Travessa</label>
+        <input type="text" class="form-control" id="logradouro" name="logradouro" autocomplete="off" disabled>
+    </div>
+    <div class="mb-3">
+        <label for="numero" class="form-label">Número</label>
+        <input type="text" class="form-control" id="numero" name="numero" autocomplete="off">
+    </div>
+    <div class="mb-3">
+        <label for="complemento" class="form-label">Complemento</label>
+        <input type="text" class="form-control" id="complemento" name="complemento" autocomplete="off">
+    </div>
+    <div class="mb-3">
+        <label for="bairro" class="form-label">Bairro</label>
+        <input type="text" class="form-control" id="bairro" name="bairro" autocomplete="off" disabled>
+    </div>
+    <div class="mb-3">
+        <label for="cidade" class="form-label">Cidade</label>
+        <input type="text" class="form-control" id="cidade" name="cidade" autocomplete="off" disabled>
+    </div>
+    <div class="mb-3">
+        <label for="estado" class="form-label">Estado</label>
+        <input type="text" class="form-control" id="estado" name="estado" autocomplete="off" disabled>
+    </div>
+    <div class="mb-3">
+        <label for="ponto_referencia" class="form-label">Ponto de referência</label>
+        <input type="text" class="form-control" id="ponto_referencia" name="ponto_referencia" autocomplete="off">
+    </div>
+    <div class="text-end">
+        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+    </div>
+</form>
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
+<script src="{{ url_for('static', filename='js/etapa2_endereco.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add route for etapa2_endereco
- enable navigation from etapa1_dados_pessoais.html to etapa2
- redirect on button click via updated JS

## Testing
- `pytest -q` *(fails: ODBC driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_68473e15c0f08320b41d797c0a16b781