### PR TITLE
Add family health step template and scripts

### DIFF
--- a/app/static/css/etapa6_saude_familiar.css
+++ b/app/static/css/etapa6_saude_familiar.css
@@ -1,0 +1,1 @@
+/* Estilos específicos para etapa 6 - saúde familiar */

--- a/app/static/js/etapa6_saude_familiar.js
+++ b/app/static/js/etapa6_saude_familiar.js
@@ -1,0 +1,52 @@
+
+document.addEventListener('DOMContentLoaded', function() {
+    const doencaRadios = document.querySelectorAll('input[name="tem_doenca_cronica"]');
+    const doencaContainer = document.getElementById('descricao_doenca_cronica_container');
+
+    const medicacaoRadios = document.querySelectorAll('input[name="usa_medicacao_continua"]');
+    const medicacaoContainer = document.getElementById('descricao_medicacao_container');
+
+    const deficienciaRadios = document.querySelectorAll('input[name="tem_deficiencia"]');
+    const deficienciaContainer = document.getElementById('descricao_deficiencia_container');
+    const bpcContainer = document.getElementById('recebe_bpc_container');
+
+    const btnProxima = document.getElementById('btnProxima');
+    const form = document.getElementById('formEtapa6');
+
+    function toggleContainer(radios, container) {
+        const selecionado = Array.from(radios).find(r => r.checked);
+        if (selecionado && selecionado.value === 'Sim') {
+            container.classList.remove('d-none');
+        } else {
+            container.classList.add('d-none');
+            const input = container.querySelector('input, textarea');
+            if (input) input.value = '';
+        }
+    }
+
+    function atualizarDeficiencia() {
+        toggleContainer(deficienciaRadios, deficienciaContainer);
+        const selecionado = Array.from(deficienciaRadios).find(r => r.checked);
+        if (selecionado && selecionado.value === 'Sim') {
+            bpcContainer.classList.remove('d-none');
+        } else {
+            bpcContainer.classList.add('d-none');
+            document.querySelectorAll('input[name="recebe_bpc"]').forEach(r => r.checked = false);
+        }
+    }
+
+    doencaRadios.forEach(r => r.addEventListener('change', () => toggleContainer(doencaRadios, doencaContainer)));
+    medicacaoRadios.forEach(r => r.addEventListener('change', () => toggleContainer(medicacaoRadios, medicacaoContainer)));
+    deficienciaRadios.forEach(r => r.addEventListener('change', atualizarDeficiencia));
+
+    // initialize state
+    toggleContainer(doencaRadios, doencaContainer);
+    toggleContainer(medicacaoRadios, medicacaoContainer);
+    atualizarDeficiencia();
+
+    if (btnProxima && form) {
+        btnProxima.addEventListener('click', function() {
+            console.log('Dados do formulário etapa 6:', Object.fromEntries(new FormData(form).entries()));
+        });
+    }
+});

--- a/app/templates/atendimento/etapa6_saude_familiar.html
+++ b/app/templates/atendimento/etapa6_saude_familiar.html
@@ -1,0 +1,80 @@
+{% extends 'base.html' %}
+{% block title %}Atendimento à Família - Etapa 6{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Etapa 6 de 9 - Saúde dos membros da família</h2>
+<form id="formEtapa6" autocomplete="off">
+    <div class="mb-3">
+        <label class="form-label">Algum morador possui alguma doença crônica?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="tem_doenca_cronica" id="tem_doenca_cronica_sim" value="Sim" autocomplete="off">
+                <label class="form-check-label" for="tem_doenca_cronica_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="tem_doenca_cronica" id="tem_doenca_cronica_nao" value="Não" autocomplete="off">
+                <label class="form-check-label" for="tem_doenca_cronica_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="mb-3 d-none" id="descricao_doenca_cronica_container">
+        <label for="descricao_doenca_cronica" class="form-label">Qual(is) doença(s)?</label>
+        <textarea class="form-control" id="descricao_doenca_cronica" name="descricao_doenca_cronica" rows="3" autocomplete="off"></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Alguém faz uso contínuo de medicamentos?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="usa_medicacao_continua" id="usa_medicacao_continua_sim" value="Sim" autocomplete="off">
+                <label class="form-check-label" for="usa_medicacao_continua_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="usa_medicacao_continua" id="usa_medicacao_continua_nao" value="Não" autocomplete="off">
+                <label class="form-check-label" for="usa_medicacao_continua_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="mb-3 d-none" id="descricao_medicacao_container">
+        <label for="descricao_medicacao" class="form-label">Qual(is) medicamento(s)?</label>
+        <textarea class="form-control" id="descricao_medicacao" name="descricao_medicacao" rows="3" autocomplete="off"></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Alguém na família possui alguma deficiência (física, mental, etc.)?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="tem_deficiencia" id="tem_deficiencia_sim" value="Sim" autocomplete="off">
+                <label class="form-check-label" for="tem_deficiencia_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="tem_deficiencia" id="tem_deficiencia_nao" value="Não" autocomplete="off">
+                <label class="form-check-label" for="tem_deficiencia_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="mb-3 d-none" id="descricao_deficiencia_container">
+        <label for="descricao_deficiencia" class="form-label">Qual tipo de deficiência?</label>
+        <textarea class="form-control" id="descricao_deficiencia" name="descricao_deficiencia" rows="3" autocomplete="off"></textarea>
+    </div>
+    <div class="mb-3 d-none" id="recebe_bpc_container">
+        <label class="form-label">A pessoa com deficiência recebe Benefício de Prestação Continuada?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="recebe_bpc" id="recebe_bpc_sim" value="Sim" autocomplete="off">
+                <label class="form-check-label" for="recebe_bpc_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="recebe_bpc" id="recebe_bpc_nao" value="Não" autocomplete="off">
+                <label class="form-check-label" for="recebe_bpc_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="text-end">
+        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+    </div>
+</form>
+{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/etapa6_saude_familiar.css') }}">
+{% endblock %}
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/etapa6_saude_familiar.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add etapa 6 template to capture family health information
- add JS to toggle health related fields
- add placeholder CSS for step 6

## Testing
- `pytest -q` *(fails: ODBC Driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1380fa1c8320b6b3eb6c3cd9eefb