### PR TITLE
Add etapa7 employment and skills page

### DIFF
--- a/app/static/css/etapa7_emprego_e_habilidades.css
+++ b/app/static/css/etapa7_emprego_e_habilidades.css
@@ -1,0 +1,1 @@
+/* Estilos específicos para etapa 7 - emprego e habilidades */

--- a/app/static/js/etapa7_emprego_e_habilidades.js
+++ b/app/static/js/etapa7_emprego_e_habilidades.js
@@ -1,0 +1,50 @@
+// JS para etapa 7 - emprego e habilidades do provedor
+
+document.addEventListener('DOMContentLoaded', function() {
+    const relacaoSelect = document.getElementById('relacao_provedor_familia');
+    const provedorExternoContainer = document.getElementById('descricao_provedor_externo_container');
+    const provedorExternoInput = document.getElementById('descricao_provedor_externo');
+
+    const situacaoSelect = document.getElementById('situacao_emprego');
+    const situacaoOutroContainer = document.getElementById('descricao_situacao_emprego_outro_container');
+    const situacaoOutroInput = document.getElementById('descricao_situacao_emprego_outro');
+
+    const btnProxima = document.getElementById('btnProxima');
+    const form = document.getElementById('formEtapa7');
+
+    function atualizarProvedorExterno() {
+        if (!relacaoSelect) return;
+        if (relacaoSelect.value === 'Provedor não familiar') {
+            provedorExternoContainer.classList.remove('d-none');
+        } else {
+            provedorExternoContainer.classList.add('d-none');
+            if (provedorExternoInput) provedorExternoInput.value = '';
+        }
+    }
+
+    function atualizarSituacaoOutro() {
+        if (!situacaoSelect) return;
+        if (situacaoSelect.value === 'Outro') {
+            situacaoOutroContainer.classList.remove('d-none');
+        } else {
+            situacaoOutroContainer.classList.add('d-none');
+            if (situacaoOutroInput) situacaoOutroInput.value = '';
+        }
+    }
+
+    if (relacaoSelect) {
+        relacaoSelect.addEventListener('change', atualizarProvedorExterno);
+        atualizarProvedorExterno();
+    }
+
+    if (situacaoSelect) {
+        situacaoSelect.addEventListener('change', atualizarSituacaoOutro);
+        atualizarSituacaoOutro();
+    }
+
+    if (btnProxima && form) {
+        btnProxima.addEventListener('click', function() {
+            console.log('Dados do formulário etapa 7:', Object.fromEntries(new FormData(form).entries()));
+        });
+    }
+});

--- a/app/templates/atendimento/etapa7_emprego_e_habilidades.html
+++ b/app/templates/atendimento/etapa7_emprego_e_habilidades.html
@@ -1,0 +1,63 @@
+{% extends 'base.html' %}
+{% block title %}Atendimento à Família - Etapa 7{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Etapa 7 de 9 - Emprego do provedor principal</h2>
+<form id="formEtapa7" autocomplete="off">
+    <div class="mb-3">
+        <label for="relacao_provedor_familia" class="form-label">Quem é o principal provedor da família?</label>
+        <select class="form-select" id="relacao_provedor_familia" name="relacao_provedor_familia" autocomplete="off">
+            <option value="" selected disabled>Selecione</option>
+            <option value="Eu mesma(o)">Eu mesma(o)</option>
+            <option value="Esposo(a)">Esposo(a)</option>
+            <option value="Filho(a)">Filho(a)</option>
+            <option value="Outro familiar">Outro familiar</option>
+            <option value="Provedor não familiar">Provedor não familiar</option>
+        </select>
+    </div>
+    <div class="mb-3 d-none" id="descricao_provedor_externo_container">
+        <label for="descricao_provedor_externo" class="form-label">Se não for da família, quem é o provedor?</label>
+        <input type="text" class="form-control" id="descricao_provedor_externo" name="descricao_provedor_externo" autocomplete="off">
+    </div>
+    <div class="mb-3">
+        <label for="situacao_emprego" class="form-label">Qual a situação de emprego do provedor principal?</label>
+        <select class="form-select" id="situacao_emprego" name="situacao_emprego" autocomplete="off">
+            <option value="" selected disabled>Selecione</option>
+            <option value="Empregado formal">Empregado formal</option>
+            <option value="Empregado informal">Empregado informal</option>
+            <option value="Desempregado">Desempregado</option>
+            <option value="Autônomo">Autônomo</option>
+            <option value="Aposentado">Aposentado</option>
+            <option value="Outro">Outro</option>
+        </select>
+    </div>
+    <div class="mb-3 d-none" id="descricao_situacao_emprego_outro_container">
+        <label for="descricao_situacao_emprego_outro" class="form-label">Descreva a situação de emprego</label>
+        <input type="text" class="form-control" id="descricao_situacao_emprego_outro" name="descricao_situacao_emprego_outro" autocomplete="off">
+    </div>
+    <div class="mb-3">
+        <label for="profissao_provedor" class="form-label">Qual a profissão atual do provedor?</label>
+        <input type="text" class="form-control" id="profissao_provedor" name="profissao_provedor" autocomplete="off">
+    </div>
+    <div class="mb-3">
+        <label for="experiencia_profissional" class="form-label">Há alguma experiência profissional relevante?</label>
+        <textarea class="form-control" id="experiencia_profissional" name="experiencia_profissional" rows="3" autocomplete="off"></textarea>
+    </div>
+    <div class="mb-3">
+        <label for="formacao_profissional" class="form-label">Formação profissional (cursos, treinamentos, etc.)</label>
+        <textarea class="form-control" id="formacao_profissional" name="formacao_profissional" rows="3" autocomplete="off"></textarea>
+    </div>
+    <div class="mb-3">
+        <label for="habilidades_relevantes" class="form-label">Outras habilidades (ex: costura, carpintaria, etc.)</label>
+        <textarea class="form-control" id="habilidades_relevantes" name="habilidades_relevantes" rows="3" autocomplete="off"></textarea>
+    </div>
+    <div class="text-end">
+        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+    </div>
+</form>
+{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/etapa7_emprego_e_habilidades.css') }}">
+{% endblock %}
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/etapa7_emprego_e_habilidades.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add etapa7 employment page template
- create JS for etapa7 conditional fields
- add CSS placeholder for etapa7

## Testing
- `pytest -q` *(fails: ODBC driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c16c6028c832081cd9a9ed3a53fc5