### PR TITLE
Implement etapa 8 - renda e gastos

### DIFF
--- a/app/static/css/etapa8_renda_e_gastos.css
+++ b/app/static/css/etapa8_renda_e_gastos.css
@@ -1,0 +1,41 @@
+/* Estilos específicos para etapa 8 - renda e gastos */
+#formEtapa8 .mb-3 {
+    margin-bottom: 0.75rem;
+}
+
+#formEtapa8 .form-label {
+    font-size: 0.9rem;
+}
+
+#formEtapa8 .form-control,
+#formEtapa8 .form-select {
+    font-size: 0.9rem;
+    padding: 0.4rem 0.7rem;
+}
+
+.beneficios-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.beneficio-tag {
+    background-color: #e9ecef;
+    border: 1px solid #dee2e6;
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.beneficio-tag:hover {
+    background-color: #dee2e6;
+    border-color: #ced4da;
+}
+
+.beneficio-tag:active {
+    background-color: #ced4da;
+    border-color: #adb5bd;
+}

--- a/app/static/js/etapa8_renda_e_gastos.js
+++ b/app/static/js/etapa8_renda_e_gastos.js
@@ -1,0 +1,214 @@
+// JS para etapa 8 - renda e gastos mensais
+
+document.addEventListener('DOMContentLoaded', function() {
+    const currencyInputs = document.querySelectorAll('.renda-decimal');
+
+    function formatCurrency(input) {
+        if (!input) return;
+        const cursorPos = input.selectionStart;
+        const prevLength = input.value.length;
+        let value = input.value.replace(/[^\d-]/g, '');
+        let negative = value.startsWith('-');
+        value = value.replace(/-/g, '');
+        value = (parseInt(value || '0') / 100).toFixed(2);
+        value = value.replace('.', ',');
+        value = value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1.');
+        input.value = `${negative ? '-' : ''}R$ ${value}`;
+        input.dataset.rawValue = (negative ? '-' : '') + (parseInt(input.value.replace(/\D/g, '')) / 100).toFixed(2);
+        if (document.activeElement === input) {
+            const newLength = input.value.length;
+            const diff = newLength - prevLength;
+            const newPos = cursorPos + diff;
+            input.setSelectionRange(newPos, newPos);
+        }
+    }
+
+    currencyInputs.forEach(input => {
+        input.addEventListener('input', function() {
+            const numbers = this.value.replace(/[^\d-]/g, '');
+            if (numbers.length > 15) {
+                this.value = this.dataset.previousValue || '';
+                return;
+            }
+            this.dataset.previousValue = this.value;
+            formatCurrency(this);
+        });
+        input.addEventListener('focus', function() {
+            if (!this.value) {
+                this.value = 'R$ 0,00';
+                this.dataset.rawValue = '0.00';
+            }
+        });
+        input.addEventListener('blur', function() {
+            if (!this.value) {
+                this.value = 'R$ 0,00';
+                this.dataset.rawValue = '0.00';
+            } else {
+                formatCurrency(this);
+            }
+        });
+        if (!input.value) {
+            input.value = 'R$ 0,00';
+            input.dataset.rawValue = '0.00';
+        } else {
+            formatCurrency(input);
+        }
+    });
+
+    const valorBotija = document.getElementById('valor_botija_gas');
+    const duracaoBotija = document.getElementById('duracao_botija_gas');
+    const gastosGas = document.getElementById('gastos_gas');
+
+    function calcularGastosGas() {
+        if (!valorBotija || !duracaoBotija || !gastosGas) return;
+        const valor = parseFloat(valorBotija.dataset.rawValue || '0');
+        const meses = parseFloat(duracaoBotija.value || '0');
+        if (meses > 0) {
+            const mensal = valor / meses;
+            gastosGas.dataset.rawValue = mensal.toFixed(2);
+            gastosGas.value = `R$ ${mensal.toFixed(2).replace('.', ',')}`;
+        } else {
+            gastosGas.dataset.rawValue = '0.00';
+            gastosGas.value = 'R$ 0,00';
+        }
+        updateTotais();
+    }
+
+    if (valorBotija && duracaoBotija) {
+        valorBotija.addEventListener('input', calcularGastosGas);
+        duracaoBotija.addEventListener('input', calcularGastosGas);
+    }
+
+    const gastosIds = [
+        'gastos_supermercado',
+        'gastos_energia_eletrica',
+        'gastos_agua',
+        'gastos_gas',
+        'gastos_transporte',
+        'gastos_medicamentos',
+        'gastos_conta_celular',
+        'gastos_outros'
+    ];
+    const rendaIds = [
+        'renda_arrimo',
+        'renda_outros_familiares',
+        'auxilio_parentes_amigos',
+        'valor_total_beneficios'
+    ];
+
+    const totalGastosInput = document.getElementById('total_gastos');
+    const rendaTotalInput = document.getElementById('renda_familiar_total');
+    const saldoInput = document.getElementById('saldo');
+
+    function somar(ids) {
+        return ids.reduce((sum, id) => {
+            const el = document.getElementById(id);
+            if (el && el.dataset.rawValue) {
+                sum += parseFloat(el.dataset.rawValue) || 0;
+            }
+            return sum;
+        }, 0);
+    }
+
+    function atualizarTotaisRenda() {
+        const total = somar(rendaIds);
+        rendaTotalInput.dataset.rawValue = total.toFixed(2);
+        rendaTotalInput.value = `R$ ${total.toFixed(2).replace('.', ',')}`;
+        atualizarSaldo();
+    }
+
+    function atualizarTotaisGastos() {
+        const total = somar(gastosIds);
+        totalGastosInput.dataset.rawValue = total.toFixed(2);
+        totalGastosInput.value = `R$ ${total.toFixed(2).replace('.', ',')}`;
+        atualizarSaldo();
+    }
+
+    function atualizarSaldo() {
+        const renda = parseFloat(rendaTotalInput.dataset.rawValue || '0');
+        const gastos = parseFloat(totalGastosInput.dataset.rawValue || '0');
+        const saldo = renda - gastos;
+        saldoInput.dataset.rawValue = saldo.toFixed(2);
+        saldoInput.value = `R$ ${saldo.toFixed(2).replace('.', ',')}`;
+        if (saldo < 0) {
+            saldoInput.classList.add('text-danger');
+            saldoInput.classList.remove('text-success');
+        } else {
+            saldoInput.classList.add('text-success');
+            saldoInput.classList.remove('text-danger');
+        }
+    }
+
+    function updateTotais() {
+        atualizarTotaisGastos();
+        atualizarTotaisRenda();
+    }
+
+    gastosIds.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('input', atualizarTotaisGastos);
+    });
+    rendaIds.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('input', atualizarTotaisRenda);
+    });
+
+    // Programas sociais
+    const beneficioSim = document.getElementById('beneficio_sim');
+    const beneficioNao = document.getElementById('beneficio_nao');
+    const beneficiosSection = document.getElementById('beneficios_section');
+    const beneficiosTags = document.querySelector('.beneficios-tags');
+    const descricaoBeneficios = document.getElementById('descricao_beneficios');
+    const valorTotalBeneficios = document.getElementById('valor_total_beneficios');
+    const valorTotalBeneficiosContainer = document.getElementById('valor_total_beneficios_container');
+
+    function toggleBeneficios() {
+        if (beneficioSim && beneficioSim.checked) {
+            beneficiosSection.style.display = 'block';
+            beneficiosTags.style.display = 'flex';
+            if (valorTotalBeneficiosContainer) valorTotalBeneficiosContainer.style.display = 'block';
+        } else {
+            beneficiosSection.style.display = 'none';
+            beneficiosTags.style.display = 'none';
+            descricaoBeneficios.value = '';
+            valorTotalBeneficios.value = 'R$ 0,00';
+            valorTotalBeneficios.dataset.rawValue = '0.00';
+            if (valorTotalBeneficiosContainer) valorTotalBeneficiosContainer.style.display = 'none';
+            updateTotais();
+        }
+    }
+
+    if (beneficioSim && beneficioNao) {
+        beneficioSim.addEventListener('change', toggleBeneficios);
+        beneficioNao.addEventListener('change', toggleBeneficios);
+        toggleBeneficios();
+    }
+
+    if (beneficiosTags) {
+        beneficiosTags.querySelectorAll('.beneficio-tag').forEach(tag => {
+            tag.addEventListener('click', function() {
+                const beneficio = this.getAttribute('data-beneficio');
+                let current = descricaoBeneficios.value.trim();
+                if (current) {
+                    const list = current.split(',').map(b => b.trim());
+                    if (!list.includes(beneficio)) {
+                        descricaoBeneficios.value = current + ', ' + beneficio;
+                    }
+                } else {
+                    descricaoBeneficios.value = beneficio;
+                }
+            });
+        });
+    }
+
+    const btnProxima = document.getElementById('btnProxima');
+    const form = document.getElementById('formEtapa8');
+    if (btnProxima && form) {
+        btnProxima.addEventListener('click', function() {
+            console.log('Dados do formulário etapa 8:', Object.fromEntries(new FormData(form).entries()));
+        });
+    }
+
+    updateTotais();
+    calcularGastosGas();
+});

--- a/app/templates/atendimento/etapa8_renda_e_gastos.html
+++ b/app/templates/atendimento/etapa8_renda_e_gastos.html
@@ -1,0 +1,123 @@
+{% extends 'base.html' %}
+{% block title %}Atendimento à Família - Etapa 8{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Etapa 8 de 9 - Renda e gastos mensais da família</h2>
+<form id="formEtapa8" autocomplete="off">
+    <div class="mb-3">
+        <label for="gastos_supermercado" class="form-label">Quanto a família gasta com supermercado?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_supermercado" name="gastos_supermercado">
+    </div>
+    <div class="mb-3">
+        <label for="gastos_energia_eletrica" class="form-label">Com energia elétrica?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_energia_eletrica" name="gastos_energia_eletrica">
+    </div>
+    <div class="mb-3">
+        <label for="gastos_agua" class="form-label">Com água?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_agua" name="gastos_agua">
+    </div>
+    <div class="row mb-3">
+        <div class="col-md-4 mb-3 mb-md-0">
+            <label for="valor_botija_gas" class="form-label">Valor de um botijão de gás</label>
+            <input type="text" class="form-control renda-decimal" id="valor_botija_gas" name="valor_botija_gas">
+        </div>
+        <div class="col-md-4 mb-3 mb-md-0">
+            <label for="duracao_botija_gas" class="form-label">Quantos meses dura um botijão?</label>
+            <input type="number" class="form-control" id="duracao_botija_gas" name="duracao_botija_gas" min="1" step="1">
+        </div>
+        <div class="col-md-4">
+            <label for="gastos_gas" class="form-label">Gasto mensal com gás</label>
+            <input type="text" class="form-control renda-decimal readonly-field" id="gastos_gas" name="gastos_gas" readonly>
+        </div>
+    </div>
+    <div class="mb-3">
+        <label for="gastos_transporte" class="form-label">Com transporte?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_transporte" name="gastos_transporte">
+    </div>
+    <div class="mb-3">
+        <label for="gastos_medicamentos" class="form-label">Com medicamentos?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_medicamentos" name="gastos_medicamentos">
+    </div>
+    <div class="mb-3">
+        <label for="gastos_conta_celular" class="form-label">Com conta de celular?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_conta_celular" name="gastos_conta_celular">
+    </div>
+    <div class="mb-3">
+        <label for="gastos_outros" class="form-label">Outros gastos?</label>
+        <input type="text" class="form-control renda-decimal" id="gastos_outros" name="gastos_outros">
+    </div>
+    <hr>
+    <div class="mb-3">
+        <label for="renda_arrimo" class="form-label">Renda mensal do provedor principal</label>
+        <input type="text" class="form-control renda-decimal" id="renda_arrimo" name="renda_arrimo">
+    </div>
+    <div class="mb-3">
+        <label for="renda_outros_familiares" class="form-label">Renda mensal dos demais moradores</label>
+        <input type="text" class="form-control renda-decimal" id="renda_outros_familiares" name="renda_outros_familiares">
+    </div>
+    <div class="mb-3">
+        <label for="auxilio_parentes_amigos" class="form-label">Ajuda de parentes, amigos ou vizinhos</label>
+        <input type="text" class="form-control renda-decimal" id="auxilio_parentes_amigos" name="auxilio_parentes_amigos">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Possui Cadastro Único?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="cadastro_unico" id="cadastro_sim" value="Sim">
+                <label class="form-check-label" for="cadastro_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="cadastro_unico" id="cadastro_nao" value="Não">
+                <label class="form-check-label" for="cadastro_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Recebe algum benefício social?</label>
+        <div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="recebe_beneficio" id="beneficio_sim" value="Sim">
+                <label class="form-check-label" for="beneficio_sim">Sim</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="recebe_beneficio" id="beneficio_nao" value="Não">
+                <label class="form-check-label" for="beneficio_nao">Não</label>
+            </div>
+        </div>
+    </div>
+    <div class="mb-3" id="beneficios_section" style="display:none;">
+        <label for="descricao_beneficios" class="form-label">Quais benefícios são recebidos?</label>
+        <div class="beneficios-tags mb-2">
+            <span class="beneficio-tag" data-beneficio="Bolsa Família">Bolsa Família</span>
+            <span class="beneficio-tag" data-beneficio="Renda Cidadã">Renda Cidadã</span>
+            <span class="beneficio-tag" data-beneficio="Ação Jovem">Ação Jovem</span>
+            <span class="beneficio-tag" data-beneficio="PAF">PAF</span>
+        </div>
+        <textarea class="form-control" id="descricao_beneficios" name="descricao_beneficios" rows="2"></textarea>
+    </div>
+    <div class="mb-3" id="valor_total_beneficios_container" style="display:none;">
+        <label for="valor_total_beneficios" class="form-label">Valor total mensal dos benefícios</label>
+        <input type="text" class="form-control renda-decimal" id="valor_total_beneficios" name="valor_total_beneficios">
+    </div>
+    <div class="mb-3">
+        <label for="renda_familiar_total" class="form-label">Renda familiar total</label>
+        <input type="text" class="form-control renda-decimal readonly-field" id="renda_familiar_total" name="renda_familiar_total" readonly>
+    </div>
+    <div class="mb-3">
+        <label for="total_gastos" class="form-label">Total de gastos</label>
+        <input type="text" class="form-control renda-decimal readonly-field" id="total_gastos" name="total_gastos" readonly>
+    </div>
+    <div class="mb-3">
+        <label for="saldo" class="form-label">Saldo</label>
+        <input type="text" class="form-control renda-decimal readonly-field" id="saldo" name="saldo" readonly>
+    </div>
+    <div class="text-end">
+        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+    </div>
+</form>
+{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/etapa8_renda_e_gastos.css') }}">
+{% endblock %}
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/etapa8_renda_e_gastos.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add stage 8 screen for income and expenses
- implement JS for automatic calculations and benefit tags
- include CSS adjustments

## Testing
- `pytest -q` *(fails: ODBC driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c857d0c148320af143b7b03e2771e