### PR TITLE
Enable navigation through all atendimento steps

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,5 +27,47 @@ def atendimento_etapa3():
     return render_template("atendimento/etapa3_composicao_familiar.html")
 
 
+@app.route("/atendimento/etapa4")
+def atendimento_etapa4():
+    """Exibe a quarta etapa do atendimento à família."""
+    return render_template("atendimento/etapa4_contato.html")
+
+
+@app.route("/atendimento/etapa5")
+def atendimento_etapa5():
+    """Exibe a quinta etapa do atendimento à família."""
+    return render_template("atendimento/etapa5_condicoes_habitacionais.html")
+
+
+@app.route("/atendimento/etapa6")
+def atendimento_etapa6():
+    """Exibe a sexta etapa do atendimento à família."""
+    return render_template("atendimento/etapa6_saude_familiar.html")
+
+
+@app.route("/atendimento/etapa7")
+def atendimento_etapa7():
+    """Exibe a sétima etapa do atendimento à família."""
+    return render_template("atendimento/etapa7_emprego_e_habilidades.html")
+
+
+@app.route("/atendimento/etapa8")
+def atendimento_etapa8():
+    """Exibe a oitava etapa do atendimento à família."""
+    return render_template("atendimento/etapa8_renda_e_gastos.html")
+
+
+@app.route("/atendimento/etapa9")
+def atendimento_etapa9():
+    """Exibe a nona etapa do atendimento à família."""
+    return render_template("atendimento/etapa9_escolaridade.html")
+
+
+@app.route("/atendimento/etapa10")
+def atendimento_etapa10():
+    """Exibe a décima etapa do atendimento à família."""
+    return render_template("atendimento/etapa10_outras_necessidades.html")
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/app/static/js/etapa10_outras_necessidades.js
+++ b/app/static/js/etapa10_outras_necessidades.js
@@ -105,6 +105,10 @@ document.addEventListener('DOMContentLoaded', function() {
         });
         if (valido) {
             console.log('Dados do formulário etapa 10:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnFinalizar.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         }
     });
 

--- a/app/static/js/etapa3_composicao_familiar.js
+++ b/app/static/js/etapa3_composicao_familiar.js
@@ -45,6 +45,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 3:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 });

--- a/app/static/js/etapa4_contato.js
+++ b/app/static/js/etapa4_contato.js
@@ -40,6 +40,10 @@ document.addEventListener('DOMContentLoaded', function() {
         btnProxima.addEventListener('click', function() {
             validarEmail();
             console.log('Dados do formulário etapa 4:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 });

--- a/app/static/js/etapa5_condicoes_habitacionais.js
+++ b/app/static/js/etapa5_condicoes_habitacionais.js
@@ -25,6 +25,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 5:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 });

--- a/app/static/js/etapa6_saude_familiar.js
+++ b/app/static/js/etapa6_saude_familiar.js
@@ -47,6 +47,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 6:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 });

--- a/app/static/js/etapa7_emprego_e_habilidades.js
+++ b/app/static/js/etapa7_emprego_e_habilidades.js
@@ -45,6 +45,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 7:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 });

--- a/app/static/js/etapa8_renda_e_gastos.js
+++ b/app/static/js/etapa8_renda_e_gastos.js
@@ -206,6 +206,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 8:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 

--- a/app/static/js/etapa9_escolaridade.js
+++ b/app/static/js/etapa9_escolaridade.js
@@ -26,6 +26,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 9:', Object.fromEntries(new FormData(form).entries()));
+            const nextUrl = btnProxima.getAttribute('data-next-url');
+            if (nextUrl) {
+                window.location.href = nextUrl;
+            }
         });
     }
 });

--- a/app/templates/atendimento/etapa10_outras_necessidades.html
+++ b/app/templates/atendimento/etapa10_outras_necessidades.html
@@ -10,7 +10,7 @@
         <button type="button" class="btn btn-secondary" id="adicionarNecessidade">Adicionar nova necessidade</button>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-success" id="btnFinalizar">Finalizar atendimento</button>
+        <button type="button" class="btn btn-success" id="btnFinalizar" data-next-url="{{ url_for('home') }}">Finalizar atendimento</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa3_composicao_familiar.html
+++ b/app/templates/atendimento/etapa3_composicao_familiar.html
@@ -45,7 +45,7 @@
         <textarea class="form-control" id="motivo_ausencia_escola" name="motivo_ausencia_escola" rows="3" autocomplete="off"></textarea>
     </div>
     <div class="text-end w-100">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa4') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa4_contato.html
+++ b/app/templates/atendimento/etapa4_contato.html
@@ -41,7 +41,7 @@
         <div id="email-feedback" class="invalid-feedback">Email inválido</div>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa5') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa5_condicoes_habitacionais.html
+++ b/app/templates/atendimento/etapa5_condicoes_habitacionais.html
@@ -96,7 +96,7 @@
         <input type="number" class="form-control" id="num_ventiladores" name="num_ventiladores" min="0" autocomplete="off">
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa6') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa6_saude_familiar.html
+++ b/app/templates/atendimento/etapa6_saude_familiar.html
@@ -68,7 +68,7 @@
         </div>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa7') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa7_emprego_e_habilidades.html
+++ b/app/templates/atendimento/etapa7_emprego_e_habilidades.html
@@ -51,7 +51,7 @@
         <textarea class="form-control" id="habilidades_relevantes" name="habilidades_relevantes" rows="3" autocomplete="off"></textarea>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa8') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa8_renda_e_gastos.html
+++ b/app/templates/atendimento/etapa8_renda_e_gastos.html
@@ -111,7 +111,7 @@
         <input type="text" class="form-control renda-decimal readonly-field" id="saldo" name="saldo" readonly>
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa9') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}

--- a/app/templates/atendimento/etapa9_escolaridade.html
+++ b/app/templates/atendimento/etapa9_escolaridade.html
@@ -35,7 +35,7 @@
         <input type="text" class="form-control" id="curso_ou_serie_atual" name="curso_ou_serie_atual" autocomplete="off">
     </div>
     <div class="text-end">
-        <button type="button" class="btn btn-primary" id="btnProxima">Próxima etapa</button>
+        <button type="button" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa10') }}">Próxima etapa</button>
     </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add missing routes in `app.py` for stages 4–10
- wire next-step URLs on templates
- redirect to next step in JS handlers

## Testing
- `pytest -q` *(fails: ODBC Driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8d77cb3c8320ad605211bd57d2b6