### PR TITLE
Fix step labels in family assistance forms

### DIFF
--- a/app/templates/atendimento/etapa1_dados_pessoais.html
+++ b/app/templates/atendimento/etapa1_dados_pessoais.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 1{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 1 de 9 - Informações pessoais do(a) entrevistado(a)</h2>
+<h2 class="mb-4 text-center">Etapa 1 de 10 - Informações pessoais do(a) entrevistado(a)</h2>
 <form id="formEtapa1" autocomplete="off">
     <div class="mb-3">
         <label for="nome_responsavel" class="form-label">Nome completo do responsável pela família</label>

--- a/app/templates/atendimento/etapa2_endereco.html
+++ b/app/templates/atendimento/etapa2_endereco.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 2{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 2 de 9 - Endereço da família</h2>
+<h2 class="mb-4 text-center">Etapa 2 de 10 - Endereço da família</h2>
 <form id="formEtapa2" autocomplete="off" class="form-endereco-grid">
 
     <!-- Checkbox -->

--- a/app/templates/atendimento/etapa3_composicao_familiar.html
+++ b/app/templates/atendimento/etapa3_composicao_familiar.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 3{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 3 de 9 - Composição familiar</h2>
+<h2 class="mb-4 text-center">Etapa 3 de 10 - Composição familiar</h2>
 <form id="formEtapa3" autocomplete="off">
     <div class="mb-3 campo-numerico">
         <label for="total_residentes" class="form-label">Quantas pessoas vivem na mesma residência?</label>

--- a/app/templates/atendimento/etapa4_contato.html
+++ b/app/templates/atendimento/etapa4_contato.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 4{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 4 de 9 - Informações de contato da família</h2>
+<h2 class="mb-4 text-center">Etapa 4 de 10 - Informações de contato da família</h2>
 <form id="formEtapa4" autocomplete="off">
     <div class="row align-items-end mb-3">
         <div class="col-md-6">

--- a/app/templates/atendimento/etapa5_condicoes_habitacionais.html
+++ b/app/templates/atendimento/etapa5_condicoes_habitacionais.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 5{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 5 de 9 - Condições habitacionais da família</h2>
+<h2 class="mb-4 text-center">Etapa 5 de 10 - Condições habitacionais da família</h2>
 <form id="formEtapa5" autocomplete="off">
     <div class="mb-3">
         <label for="tipo_moradia" class="form-label">Tipo de moradia</label>

--- a/app/templates/atendimento/etapa6_saude_familiar.html
+++ b/app/templates/atendimento/etapa6_saude_familiar.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 6{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 6 de 9 - Saúde dos membros da família</h2>
+<h2 class="mb-4 text-center">Etapa 6 de 10 - Saúde dos membros da família</h2>
 <form id="formEtapa6" autocomplete="off">
     <div class="mb-3">
         <label class="form-label">Algum morador possui alguma doença crônica?</label>

--- a/app/templates/atendimento/etapa7_emprego_e_habilidades.html
+++ b/app/templates/atendimento/etapa7_emprego_e_habilidades.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 7{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 7 de 9 - Emprego do provedor principal</h2>
+<h2 class="mb-4 text-center">Etapa 7 de 10 - Emprego do provedor principal</h2>
 <form id="formEtapa7" autocomplete="off">
     <div class="mb-3">
         <label for="relacao_provedor_familia" class="form-label">Quem é o principal provedor da família?</label>

--- a/app/templates/atendimento/etapa8_renda_e_gastos.html
+++ b/app/templates/atendimento/etapa8_renda_e_gastos.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 8{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 8 de 9 - Renda e gastos mensais da família</h2>
+<h2 class="mb-4 text-center">Etapa 8 de 10 - Renda e gastos mensais da família</h2>
 <form id="formEtapa8" autocomplete="off">
     <div class="mb-3">
         <label for="gastos_supermercado" class="form-label">Quanto a família gasta com supermercado?</label>


### PR DESCRIPTION
## Summary
- fix template titles in atendimento forms to show *de 10*

## Testing
- `pytest -q` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8fdfca7c83208301155f21316ba9