### PR TITLE
Implement menu for atendimento

### DIFF
--- a/app/templates/atendimento/etapa0_menu.html
+++ b/app/templates/atendimento/etapa0_menu.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Atendimento à Família - Menu{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Menu de Atendimento</h2>
+<div class="d-flex flex-column align-items-center gap-3">
+    <a href="#" class="btn btn-primary">Atender família</a>
+    <a href="{{ url_for('atendimento_nova_familia') }}" class="btn btn-success">Registrar nova família</a>
+    <a href="{{ url_for('retomar_atendimento') }}" class="btn btn-secondary">Retomar atendimento em andamento</a>
+</div>
+{% if error_msg %}
+<div id="retomar-feedback" class="invalid-feedback d-block text-center mt-3">{{ error_msg }}</div>
+{% endif %}
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,7 +20,7 @@
         </button>
         <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
             <ul class="navbar-nav align-items-center">                
-                <li class="nav-item"><a class="nav-link" href="{{ url_for('atendimento_etapa1') }}">Atendimento à Família</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('menu_atendimento') }}">Atendimento à Família</a></li>
                 <li class="nav-item"><a class="nav-link" href="#">Relatórios</a></li>
                 <li class="nav-item"><a class="nav-link" href="#">Administração</a></li>
             </ul>


### PR DESCRIPTION
## Summary
- add new menu page for atendimento
- add routes to start or resume atendimento
- update navbar link to new menu
- store session start time and allow resuming when recent

## Testing
- `pytest -q` *(fails: TypeError quote_from_bytes expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_684d6cd684a083209dff5dfe575d721b