### PR TITLE
Add status_cadastro field to Familia

### DIFF
--- a/app/models/familia.py
+++ b/app/models/familia.py
@@ -13,6 +13,9 @@ class Familia(db.Model):
     rg = db.Column(db.String(20))
     cpf = db.Column(db.String(14))
     autoriza_uso_imagem = db.Column(db.Boolean)
+    status_cadastro = db.Column(
+        db.String(20), nullable=False, default="rascunho"
+    )
     data_hora_log_utc = db.Column(
         db.DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/app/schemas/familia.py
+++ b/app/schemas/familia.py
@@ -25,6 +25,7 @@ class FamiliaSchema(ma.SQLAlchemySchema):
     rg = ma.auto_field()
     cpf = ma.auto_field()
     autoriza_uso_imagem = ma.auto_field()
+    status_cadastro = ma.auto_field()
     data_hora_log_utc = ma.auto_field(dump_only=True)
 
     @validates("estado_civil")
@@ -68,6 +69,11 @@ class FamiliaSchema(ma.SQLAlchemySchema):
             return False
 
         return True
+
+    @validates("status_cadastro")
+    def validar_status(self, value, **kwargs):
+        if value not in ["rascunho", "finalizado"]:
+            raise ValidationError("Status inválido.")
 
     @validates_schema
     def validate_genero_autodeclarado(self, data, **kwargs):


### PR DESCRIPTION
## Summary
- add `status_cadastro` column in `Familia` model
- expose new field in `FamiliaSchema` with validation

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_684d8e97b57883208f1322cb02b1930b