### PR TITLE
Implement demand management models and routes

### DIFF
--- a/app/models/demanda_etapa.py
+++ b/app/models/demanda_etapa.py
@@ -1,0 +1,16 @@
+from app import db
+from datetime import datetime, timezone
+
+class DemandaEtapa(db.Model):
+    __tablename__ = "demanda_etapa"
+
+    etapa_id = db.Column(db.Integer, primary_key=True)
+    demanda_id = db.Column(db.Integer, nullable=False)
+    data_atualizacao = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    status_atual = db.Column(db.String(20), nullable=False)
+    observacao = db.Column(db.Text)
+    usuario_atualizacao = db.Column(db.String(100))

--- a/app/models/demanda_familia.py
+++ b/app/models/demanda_familia.py
@@ -1,0 +1,18 @@
+from app import db
+from datetime import datetime, timezone
+
+class DemandaFamilia(db.Model):
+    __tablename__ = "demanda_familia"
+
+    demanda_id = db.Column(db.Integer, primary_key=True)
+    familia_id = db.Column(db.Integer, nullable=False)
+    demanda_tipo_id = db.Column(db.Integer, nullable=False)
+    descricao = db.Column(db.Text)
+    data_identificacao = db.Column(db.Date, nullable=False)
+    prioridade = db.Column(db.String(20))
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/app/models/demanda_tipo.py
+++ b/app/models/demanda_tipo.py
@@ -1,0 +1,14 @@
+from app import db
+from datetime import datetime, timezone
+
+class DemandaTipo(db.Model):
+    __tablename__ = "demanda_tipo"
+
+    demanda_tipo_id = db.Column(db.Integer, primary_key=True)
+    demanda_tipo_nome = db.Column(db.String(100), nullable=False)
+    data_hora_log_utc = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -7,6 +7,9 @@ from app.routes.endereco import bp as endereco_bp
 from app.routes.saude_familiar import bp as saude_familiar_bp
 from app.routes.educacao_entrevistado import bp as educacao_entrevistado_bp
 from app.routes.emprego_provedor import bp as emprego_provedor_bp
+from app.routes.demanda_tipo import bp as demanda_tipo_bp
+from app.routes.demanda_familia import bp as demanda_familia_bp
+from app.routes.demanda_etapa import bp as demanda_etapa_bp
 
 def register_routes(app):
     app.register_blueprint(familia_bp)
@@ -18,3 +21,6 @@ def register_routes(app):
     app.register_blueprint(saude_familiar_bp)
     app.register_blueprint(educacao_entrevistado_bp)
     app.register_blueprint(emprego_provedor_bp)
+    app.register_blueprint(demanda_tipo_bp)
+    app.register_blueprint(demanda_familia_bp)
+    app.register_blueprint(demanda_etapa_bp)

--- a/app/routes/demanda_etapa.py
+++ b/app/routes/demanda_etapa.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.demanda_etapa import DemandaEtapa
+from app.schemas.demanda_etapa import DemandaEtapaSchema
+from app import db
+
+bp = Blueprint("demanda_etapas", __name__, url_prefix="/demanda_etapas")
+
+demanda_etapa_schema = DemandaEtapaSchema()
+demanda_etapas_schema = DemandaEtapaSchema(many=True)
+
+@bp.route("", methods=["POST"])
+def criar_demanda_etapa():
+    data = request.get_json()
+    try:
+        nova_etapa = demanda_etapa_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(nova_etapa)
+    db.session.commit()
+    return demanda_etapa_schema.jsonify(nova_etapa), 201
+
+@bp.route("", methods=["GET"])
+def listar_demanda_etapas():
+    etapas = DemandaEtapa.query.all()
+    return demanda_etapas_schema.jsonify(etapas), 200
+
+@bp.route("/<int:etapa_id>", methods=["GET"])
+def obter_demanda_etapa(etapa_id):
+    etapa = db.session.get(DemandaEtapa, etapa_id)
+    if not etapa:
+        return jsonify({"mensagem": "Etapa não encontrada"}), 404
+    return demanda_etapa_schema.jsonify(etapa)
+
+@bp.route("/<int:etapa_id>", methods=["PUT"])
+def atualizar_demanda_etapa(etapa_id):
+    etapa = db.session.get(DemandaEtapa, etapa_id)
+    if not etapa:
+        return jsonify({"mensagem": "Etapa não encontrada"}), 404
+
+    data = request.get_json()
+    etapa = demanda_etapa_schema.load(data, instance=etapa, partial=True)
+
+    db.session.commit()
+    return demanda_etapa_schema.jsonify(etapa)
+
+@bp.route("/<int:etapa_id>", methods=["DELETE"])
+def deletar_demanda_etapa(etapa_id):
+    etapa = db.session.get(DemandaEtapa, etapa_id)
+    if not etapa:
+        return jsonify({"mensagem": "Etapa não encontrada"}), 404
+
+    db.session.delete(etapa)
+    db.session.commit()
+    return jsonify({"mensagem": "Etapa deletada com sucesso"}), 200

--- a/app/routes/demanda_familia.py
+++ b/app/routes/demanda_familia.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.demanda_familia import DemandaFamilia
+from app.schemas.demanda_familia import DemandaFamiliaSchema
+from app import db
+
+bp = Blueprint("demandas", __name__, url_prefix="/demandas")
+
+demanda_schema = DemandaFamiliaSchema()
+demandas_schema = DemandaFamiliaSchema(many=True)
+
+@bp.route("", methods=["POST"])
+def criar_demanda():
+    data = request.get_json()
+    try:
+        nova_demanda = demanda_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(nova_demanda)
+    db.session.commit()
+    return demanda_schema.jsonify(nova_demanda), 201
+
+@bp.route("", methods=["GET"])
+def listar_demandas():
+    demandas = DemandaFamilia.query.all()
+    return demandas_schema.jsonify(demandas), 200
+
+@bp.route("/<int:demanda_id>", methods=["GET"])
+def obter_demanda(demanda_id):
+    demanda = db.session.get(DemandaFamilia, demanda_id)
+    if not demanda:
+        return jsonify({"mensagem": "Demanda não encontrada"}), 404
+    return demanda_schema.jsonify(demanda)
+
+@bp.route("/<int:demanda_id>", methods=["PUT"])
+def atualizar_demanda(demanda_id):
+    demanda = db.session.get(DemandaFamilia, demanda_id)
+    if not demanda:
+        return jsonify({"mensagem": "Demanda não encontrada"}), 404
+
+    data = request.get_json()
+    demanda = demanda_schema.load(data, instance=demanda, partial=True)
+
+    db.session.commit()
+    return demanda_schema.jsonify(demanda)
+
+@bp.route("/<int:demanda_id>", methods=["DELETE"])
+def deletar_demanda(demanda_id):
+    demanda = db.session.get(DemandaFamilia, demanda_id)
+    if not demanda:
+        return jsonify({"mensagem": "Demanda não encontrada"}), 404
+
+    db.session.delete(demanda)
+    db.session.commit()
+    return jsonify({"mensagem": "Demanda deletada com sucesso"}), 200

--- a/app/routes/demanda_tipo.py
+++ b/app/routes/demanda_tipo.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import ValidationError
+from app.models.demanda_tipo import DemandaTipo
+from app.schemas.demanda_tipo import DemandaTipoSchema
+from app import db
+
+bp = Blueprint("demanda_tipos", __name__, url_prefix="/demanda_tipos")
+
+demanda_tipo_schema = DemandaTipoSchema()
+demanda_tipos_schema = DemandaTipoSchema(many=True)
+
+@bp.route("", methods=["POST"])
+def criar_demanda_tipo():
+    data = request.get_json()
+    try:
+        novo_tipo = demanda_tipo_schema.load(data)
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+
+    db.session.add(novo_tipo)
+    db.session.commit()
+    return demanda_tipo_schema.jsonify(novo_tipo), 201
+
+@bp.route("", methods=["GET"])
+def listar_demanda_tipos():
+    tipos = DemandaTipo.query.all()
+    return demanda_tipos_schema.jsonify(tipos), 200
+
+@bp.route("/<int:demanda_tipo_id>", methods=["GET"])
+def obter_demanda_tipo(demanda_tipo_id):
+    tipo = db.session.get(DemandaTipo, demanda_tipo_id)
+    if not tipo:
+        return jsonify({"mensagem": "Demanda tipo não encontrada"}), 404
+    return demanda_tipo_schema.jsonify(tipo)
+
+@bp.route("/<int:demanda_tipo_id>", methods=["PUT"])
+def atualizar_demanda_tipo(demanda_tipo_id):
+    tipo = db.session.get(DemandaTipo, demanda_tipo_id)
+    if not tipo:
+        return jsonify({"mensagem": "Demanda tipo não encontrada"}), 404
+
+    data = request.get_json()
+    tipo = demanda_tipo_schema.load(data, instance=tipo, partial=True)
+
+    db.session.commit()
+    return demanda_tipo_schema.jsonify(tipo)
+
+@bp.route("/<int:demanda_tipo_id>", methods=["DELETE"])
+def deletar_demanda_tipo(demanda_tipo_id):
+    tipo = db.session.get(DemandaTipo, demanda_tipo_id)
+    if not tipo:
+        return jsonify({"mensagem": "Demanda tipo não encontrada"}), 404
+
+    db.session.delete(tipo)
+    db.session.commit()
+    return jsonify({"mensagem": "Demanda tipo deletada com sucesso"}), 200

--- a/app/schemas/demanda_etapa.py
+++ b/app/schemas/demanda_etapa.py
@@ -1,0 +1,14 @@
+from app import ma
+from app.models.demanda_etapa import DemandaEtapa
+
+class DemandaEtapaSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = DemandaEtapa
+        load_instance = True
+
+    etapa_id = ma.auto_field(dump_only=True)
+    demanda_id = ma.auto_field()
+    data_atualizacao = ma.auto_field()
+    status_atual = ma.auto_field()
+    observacao = ma.auto_field()
+    usuario_atualizacao = ma.auto_field()

--- a/app/schemas/demanda_familia.py
+++ b/app/schemas/demanda_familia.py
@@ -1,0 +1,15 @@
+from app import ma
+from app.models.demanda_familia import DemandaFamilia
+
+class DemandaFamiliaSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = DemandaFamilia
+        load_instance = True
+
+    demanda_id = ma.auto_field(dump_only=True)
+    familia_id = ma.auto_field()
+    demanda_tipo_id = ma.auto_field()
+    descricao = ma.auto_field()
+    data_identificacao = ma.auto_field()
+    prioridade = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)

--- a/app/schemas/demanda_tipo.py
+++ b/app/schemas/demanda_tipo.py
@@ -1,0 +1,11 @@
+from app import ma
+from app.models.demanda_tipo import DemandaTipo
+
+class DemandaTipoSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = DemandaTipo
+        load_instance = True
+
+    demanda_tipo_id = ma.auto_field(dump_only=True)
+    demanda_tipo_nome = ma.auto_field()
+    data_hora_log_utc = ma.auto_field(dump_only=True)


### PR DESCRIPTION
## Summary
- add DemandaTipo, DemandaFamilia and DemandaEtapa models
- create schemas for the new demand entities
- expose CRUD routes for the demand tables
- register new blueprints

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_684fd04132b4832084257df4ce8105a0