### PR TITLE
Implement validation for DemandaFamilia

### DIFF
--- a/app/models/demanda_familia.py
+++ b/app/models/demanda_familia.py
@@ -7,6 +7,7 @@ class DemandaFamilia(db.Model):
     demanda_id = db.Column(db.Integer, primary_key=True)
     familia_id = db.Column(db.Integer, nullable=False)
     demanda_tipo_id = db.Column(db.Integer, nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="Em análise")
     descricao = db.Column(db.Text)
     data_identificacao = db.Column(db.Date, nullable=False)
     prioridade = db.Column(db.String(20))

--- a/app/schemas/demanda_etapa.py
+++ b/app/schemas/demanda_etapa.py
@@ -1,4 +1,15 @@
 from app import ma
+from marshmallow import validates, ValidationError
+
+STATUS_PERMITIDOS = [
+    "Em análise",
+    "Em andamento",
+    "Encaminhada",
+    "Aguardando resposta",
+    "Suspensa",
+    "Cancelada",
+    "Concluída",
+]
 from app.models.demanda_etapa import DemandaEtapa
 
 class DemandaEtapaSchema(ma.SQLAlchemySchema):
@@ -12,3 +23,8 @@ class DemandaEtapaSchema(ma.SQLAlchemySchema):
     status_atual = ma.auto_field()
     observacao = ma.auto_field()
     usuario_atualizacao = ma.auto_field()
+
+    @validates("status_atual")
+    def validar_status(self, value, **kwargs):
+        if value not in STATUS_PERMITIDOS:
+            raise ValidationError("Status inválido.")

--- a/app/schemas/demanda_familia.py
+++ b/app/schemas/demanda_familia.py
@@ -1,5 +1,19 @@
-from app import ma
+from app import ma, db
 from app.models.demanda_familia import DemandaFamilia
+from app.models.demanda_tipo import DemandaTipo
+from marshmallow import validates, ValidationError
+
+STATUS_PERMITIDOS = [
+    "Em análise",
+    "Em andamento",
+    "Encaminhada",
+    "Aguardando resposta",
+    "Suspensa",
+    "Cancelada",
+    "Concluída",
+]
+
+DEMANDA_TIPOS_VALIDOS = [1, 2, 3, 4, 5, 6, 7]
 
 class DemandaFamiliaSchema(ma.SQLAlchemySchema):
     class Meta:
@@ -9,7 +23,20 @@ class DemandaFamiliaSchema(ma.SQLAlchemySchema):
     demanda_id = ma.auto_field(dump_only=True)
     familia_id = ma.auto_field()
     demanda_tipo_id = ma.auto_field()
+    status = ma.auto_field()
     descricao = ma.auto_field()
     data_identificacao = ma.auto_field()
     prioridade = ma.auto_field()
     data_hora_log_utc = ma.auto_field(dump_only=True)
+
+    @validates("status")
+    def validar_status(self, value, **kwargs):
+        if value not in STATUS_PERMITIDOS:
+            raise ValidationError("Status inválido.")
+
+    @validates("demanda_tipo_id")
+    def validar_demanda_tipo(self, value, **kwargs):
+        if value not in DEMANDA_TIPOS_VALIDOS:
+            raise ValidationError("demanda_tipo_id inválido.")
+        if not db.session.get(DemandaTipo, value):
+            raise ValidationError("demanda_tipo_id não encontrado.")

--- a/tests/test_demanda_familia_routes.py
+++ b/tests/test_demanda_familia_routes.py
@@ -1,0 +1,80 @@
+import pytest
+from app import create_app
+
+_familia_id = None
+_demanda_id = None
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+def criar_familia(client):
+    global _familia_id
+    if not _familia_id:
+        payload = {
+            "nome_responsavel": "Teste Pytest",
+            "autoriza_uso_imagem": True
+        }
+        resp = client.post("/familias", json=payload)
+        assert resp.status_code == 201
+        _familia_id = resp.get_json()["familia_id"]
+    return _familia_id
+
+
+def test_post_demanda_status_default(client):
+    familia_id = criar_familia(client)
+    payload = {
+        "familia_id": familia_id,
+        "demanda_tipo_id": 1,
+        "descricao": "Teste demanda",
+        "data_identificacao": "2024-01-01"
+    }
+    resp = client.post("/demandas", json=payload)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["status"] == "Em análise"
+    global _demanda_id
+    _demanda_id = data["demanda_id"]
+
+
+def test_post_demanda_status_invalido(client):
+    familia_id = criar_familia(client)
+    payload = {
+        "familia_id": familia_id,
+        "demanda_tipo_id": 1,
+        "status": "Invalido",
+        "data_identificacao": "2024-01-01"
+    }
+    resp = client.post("/demandas", json=payload)
+    assert resp.status_code == 400
+
+
+def test_post_demanda_tipo_invalido(client):
+    familia_id = criar_familia(client)
+    payload = {
+        "familia_id": familia_id,
+        "demanda_tipo_id": 999,
+        "data_identificacao": "2024-01-01"
+    }
+    resp = client.post("/demandas", json=payload)
+    assert resp.status_code == 400
+
+
+def test_put_demanda_status_invalido(client):
+    global _demanda_id
+    update_payload = {"status": "Nao existe"}
+    resp = client.put(f"/demandas/{_demanda_id}", json=update_payload)
+    assert resp.status_code == 400
+
+
+def test_cleanup_demanda_familia(client):
+    global _familia_id, _demanda_id
+    if _demanda_id:
+        client.delete(f"/demandas/{_demanda_id}")
+    if _familia_id:
+        client.delete(f"/familias/{_familia_id}")


### PR DESCRIPTION
## Summary
- add `status` column to `DemandaFamilia` model
- validate allowed status values and demanda_tipo_id in DemandaFamilia schema
- validate stage status in DemandaEtapa schema
- add tests covering creation and update rules for demandas familiares

## Testing
- `pytest tests/test_demanda_familia_routes.py::test_post_demanda_status_default -q` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe000608883208afecd12ec7b2703