### PR TITLE
Fix total gastos to include rental cost

### DIFF
--- a/app/static/js/etapa5_condicoes_habitacionais.js
+++ b/app/static/js/etapa5_condicoes_habitacionais.js
@@ -5,6 +5,15 @@ document.addEventListener('DOMContentLoaded', function() {
     const btnProxima = document.getElementById('btnProxima');
     const form = document.getElementById('formEtapa5');
 
+    function saveValorAluguel() {
+        if (!tipoMoradiaSelect) return;
+        if (tipoMoradiaSelect.value === 'Alugada' && valorAluguelInput) {
+            sessionStorage.setItem('valor_aluguel', valorAluguelInput.value || '0');
+        } else {
+            sessionStorage.removeItem('valor_aluguel');
+        }
+    }
+
     function atualizarValorAluguel() {
         if (!tipoMoradiaSelect) return;
         if (tipoMoradiaSelect.value === 'Alugada') {
@@ -18,13 +27,21 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     if (tipoMoradiaSelect) {
-        tipoMoradiaSelect.addEventListener('change', atualizarValorAluguel);
+        tipoMoradiaSelect.addEventListener('change', function() {
+            atualizarValorAluguel();
+            saveValorAluguel();
+        });
         atualizarValorAluguel();
+    }
+
+    if (valorAluguelInput) {
+        valorAluguelInput.addEventListener('input', saveValorAluguel);
     }
 
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 5:', Object.fromEntries(new FormData(form).entries()));
+            saveValorAluguel();
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa8_renda_e_gastos.js
+++ b/app/static/js/etapa8_renda_e_gastos.js
@@ -3,6 +3,20 @@
 document.addEventListener('DOMContentLoaded', function() {
     const currencyInputs = document.querySelectorAll('.renda-decimal');
 
+    let valorAluguel = 0;
+    function carregarValorAluguel() {
+        const armazenado = sessionStorage.getItem('valor_aluguel');
+        if (armazenado !== null) {
+            valorAluguel = parseFloat(armazenado) || 0;
+        } else {
+            const hidden = document.getElementById('valor_aluguel_hidden');
+            if (hidden) {
+                valorAluguel = parseFloat(hidden.dataset.rawValue || hidden.value || '0') || 0;
+            }
+        }
+        console.log('Valor aluguel recuperado:', valorAluguel);
+    }
+
     function formatCurrency(input) {
         if (!input) return;
         const cursorPos = input.selectionStart;
@@ -118,7 +132,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function atualizarTotaisGastos() {
-        const total = somar(gastosIds);
+        const total = somar(gastosIds) + valorAluguel;
         totalGastosInput.dataset.rawValue = total.toFixed(2);
         totalGastosInput.value = `R$ ${total.toFixed(2).replace('.', ',')}`;
         atualizarSaldo();
@@ -219,6 +233,7 @@ document.addEventListener('DOMContentLoaded', function() {
         window.location.href = this.dataset.prevUrl;
     });
 
+    carregarValorAluguel();
     updateTotais();
     calcularGastosGas();
 });

--- a/app/templates/atendimento/etapa8_renda_e_gastos.html
+++ b/app/templates/atendimento/etapa8_renda_e_gastos.html
@@ -110,6 +110,7 @@
         <label for="saldo" class="form-label">Saldo</label>
         <input type="text" class="form-control renda-decimal readonly-field" id="saldo" name="saldo" readonly value="{{ session['cadastro'].get('saldo', '') }}">
     </div>
+    <input type="hidden" id="valor_aluguel_hidden" data-raw-value="{{ session['cadastro'].get('valor_aluguel', 0) }}">
     <div class="d-flex justify-content-between">
         <a href="{{ url_for('atendimento_etapa7') }}" class="btn btn-secondary" id="btnVoltar">Voltar</a>
         <button type="submit" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('atendimento_etapa9') }}">Próxima etapa</button>


### PR DESCRIPTION
## Summary
- track rental value in session storage on step 5
- read stored rental value during step 8 calculations
- add hidden field with the stored rental value
- include rent in expense and balance calculations

## Testing
- `pytest -q` *(fails: DB connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_685525b159f88320ace5cbcc56a2f6b6