### PR TITLE
Fix session persistence across steps

### DIFF
--- a/app/static/js/etapa10_outras_necessidades.js
+++ b/app/static/js/etapa10_outras_necessidades.js
@@ -1,6 +1,7 @@
 // JS para etapa 10 - outras necessidades informadas
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const lista = document.getElementById('necessidadesLista');
     const btnAdicionar = document.getElementById('adicionarNecessidade');
     const btnFinalizar = document.getElementById('btnFinalizar');

--- a/app/static/js/etapa1_dados_pessoais.js
+++ b/app/static/js/etapa1_dados_pessoais.js
@@ -25,6 +25,7 @@ function aplicarMascaraCPF(valor) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const dataInput = document.getElementById('data_nascimento');
     if (dataInput) {
         const hoje = new Date();
@@ -106,6 +107,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     btnProxima.addEventListener('click', function() {
         console.log('Dados do formulário etapa 1:', Object.fromEntries(new FormData(form).entries()));
+        console.log('Estado atual da sessão:', window.sessionCadastro);
         const nextUrl = btnProxima.getAttribute('data-next-url');
         if (nextUrl) {
             form.action = nextUrl;

--- a/app/static/js/etapa2_endereco.js
+++ b/app/static/js/etapa2_endereco.js
@@ -1,6 +1,7 @@
 // JS para etapa 2 - endereço da família
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const cepInput = document.getElementById('cep');
     const manualCheckbox = document.getElementById('preenchimento_manual');
     const cepFeedback = document.getElementById('cep-feedback');
@@ -80,6 +81,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 2:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa3_composicao_familiar.js
+++ b/app/static/js/etapa3_composicao_familiar.js
@@ -1,6 +1,7 @@
 // JS para etapa 3 - composicao familiar
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const bebes = document.getElementById('quantidade_bebes');
     const criancas = document.getElementById('quantidade_criancas');
     const adolescentes = document.getElementById('quantidade_adolescentes');
@@ -42,9 +43,14 @@ document.addEventListener('DOMContentLoaded', function() {
         el.addEventListener('change', atualizarMotivo);
     });
 
+    // adjust visibility based on loaded values
+    atualizarCampoEscola();
+    atualizarMotivo();
+
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 3:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa4_contato.js
+++ b/app/static/js/etapa4_contato.js
@@ -1,6 +1,7 @@
 // JS para etapa 4 - contato
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const telefonePrincipal = document.getElementById('telefone_principal');
     const telefoneAlternativo = document.getElementById('telefone_alternativo');
     const emailInput = document.getElementById('email_responsavel');
@@ -40,6 +41,7 @@ document.addEventListener('DOMContentLoaded', function() {
         btnProxima.addEventListener('click', function() {
             validarEmail();
             console.log('Dados do formulário etapa 4:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa5_condicoes_habitacionais.js
+++ b/app/static/js/etapa5_condicoes_habitacionais.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const tipoMoradiaSelect = document.getElementById('tipo_moradia');
     const valorAluguelContainer = document.getElementById('valor_aluguel_container');
     const valorAluguelInput = document.getElementById('valor_aluguel');
@@ -41,6 +42,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 5:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             saveValorAluguel();
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {

--- a/app/static/js/etapa6_saude_familiar.js
+++ b/app/static/js/etapa6_saude_familiar.js
@@ -1,5 +1,6 @@
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const doencaRadios = document.querySelectorAll('input[name="tem_doenca_cronica"]');
     const doencaContainer = document.getElementById('descricao_doenca_cronica_container');
 
@@ -47,6 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 6:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa7_emprego_e_habilidades.js
+++ b/app/static/js/etapa7_emprego_e_habilidades.js
@@ -1,6 +1,7 @@
 // JS para etapa 7 - emprego e habilidades do provedor
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const relacaoSelect = document.getElementById('relacao_provedor_familia');
     const provedorExternoContainer = document.getElementById('descricao_provedor_externo_container');
     const provedorExternoInput = document.getElementById('descricao_provedor_externo');
@@ -45,6 +46,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 7:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa8_renda_e_gastos.js
+++ b/app/static/js/etapa8_renda_e_gastos.js
@@ -1,6 +1,7 @@
 // JS para etapa 8 - renda e gastos mensais
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const currencyInputs = document.querySelectorAll('.renda-decimal');
 
     let valorAluguel = 0;
@@ -220,6 +221,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 8:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/static/js/etapa9_escolaridade.js
+++ b/app/static/js/etapa9_escolaridade.js
@@ -1,6 +1,7 @@
 // JS para etapa 9 - escolaridade do entrevistado
 
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('Estado atual da sessão:', window.sessionCadastro);
     const estudaSim = document.getElementById('estuda_sim');
     const estudaNao = document.getElementById('estuda_nao');
     const cursoContainer = document.getElementById('curso_ou_serie_atual_container');
@@ -26,6 +27,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (btnProxima && form) {
         btnProxima.addEventListener('click', function() {
             console.log('Dados do formulário etapa 9:', Object.fromEntries(new FormData(form).entries()));
+            console.log('Estado atual da sessão:', window.sessionCadastro);
             const nextUrl = btnProxima.getAttribute('data-next-url');
             if (nextUrl) {
                 form.action = nextUrl;

--- a/app/templates/atendimento/etapa3_composicao_familiar.html
+++ b/app/templates/atendimento/etapa3_composicao_familiar.html
@@ -5,44 +5,44 @@
 <form id="formEtapa3" autocomplete="off">
     <div class="mb-3 campo-numerico">
         <label for="total_residentes" class="form-label">Quantas pessoas vivem na mesma residência?</label>
-        <input type="number" class="form-control" id="total_residentes" name="total_residentes" min="0" autocomplete="off">
+        <input type="number" class="form-control" id="total_residentes" name="total_residentes" min="0" autocomplete="off" value="{{ session['cadastro'].get('total_residentes', '') }}">
     </div>
     <div class="mb-3 campo-numerico">
         <label for="quantidade_bebes" class="form-label">Quantos bebês (0 a 2 anos)?</label>
-        <input type="number" class="form-control" id="quantidade_bebes" name="quantidade_bebes" min="0" autocomplete="off">
+        <input type="number" class="form-control" id="quantidade_bebes" name="quantidade_bebes" min="0" autocomplete="off" value="{{ session['cadastro'].get('quantidade_bebes', '') }}">
     </div>
     <div class="mb-3 campo-numerico">
         <label for="quantidade_criancas" class="form-label">Quantas crianças (3 a 11 anos)?</label>
-        <input type="number" class="form-control" id="quantidade_criancas" name="quantidade_criancas" min="0" autocomplete="off">
+        <input type="number" class="form-control" id="quantidade_criancas" name="quantidade_criancas" min="0" autocomplete="off" value="{{ session['cadastro'].get('quantidade_criancas', '') }}">
     </div>
     <div class="mb-3 campo-numerico">
         <label for="quantidade_adolescentes" class="form-label">Quantos adolescentes (12 a 17 anos)?</label>
-        <input type="number" class="form-control" id="quantidade_adolescentes" name="quantidade_adolescentes" min="0" autocomplete="off">
+        <input type="number" class="form-control" id="quantidade_adolescentes" name="quantidade_adolescentes" min="0" autocomplete="off" value="{{ session['cadastro'].get('quantidade_adolescentes', '') }}">
     </div>
     <div class="mb-3 campo-numerico">
         <label for="quantidade_adultos" class="form-label">Quantos adultos (18 a 59 anos)?</label>
-        <input type="number" class="form-control" id="quantidade_adultos" name="quantidade_adultos" min="0" autocomplete="off">
+        <input type="number" class="form-control" id="quantidade_adultos" name="quantidade_adultos" min="0" autocomplete="off" value="{{ session['cadastro'].get('quantidade_adultos', '') }}">
     </div>
     <div class="mb-3 campo-numerico">
         <label for="quantidade_idosos" class="form-label">Quantos idosos (60 anos ou mais)?</label>
-        <input type="number" class="form-control" id="quantidade_idosos" name="quantidade_idosos" min="0" autocomplete="off">
+        <input type="number" class="form-control" id="quantidade_idosos" name="quantidade_idosos" min="0" autocomplete="off" value="{{ session['cadastro'].get('quantidade_idosos', '') }}">
     </div>
     <div id="menores_na_escola_container" class="mb-3 campo-numerico d-none">
         <label class="form-label">As crianças e adolescentes estão frequentando a escola?</label>
         <div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="menores_na_escola" id="menores_na_escola_sim" value="Sim">
+                <input class="form-check-input" type="radio" name="menores_na_escola" id="menores_na_escola_sim" value="Sim" {% if session['cadastro'].get('menores_na_escola')=='Sim' %}checked{% endif %}>
                 <label class="form-check-label" for="menores_na_escola_sim">Sim</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="menores_na_escola" id="menores_na_escola_nao" value="Não">
+                <input class="form-check-input" type="radio" name="menores_na_escola" id="menores_na_escola_nao" value="Não" {% if session['cadastro'].get('menores_na_escola')=='Não' %}checked{% endif %}>
                 <label class="form-check-label" for="menores_na_escola_nao">Não</label>
             </div>
         </div>
     </div>
     <div id="motivo_ausencia_escola_container" class="mb-3 d-none w-100">
         <label for="motivo_ausencia_escola" class="form-label">Se não estiverem todos na escola, por quê?</label>
-        <textarea class="form-control" id="motivo_ausencia_escola" name="motivo_ausencia_escola" rows="3" autocomplete="off"></textarea>
+        <textarea class="form-control" id="motivo_ausencia_escola" name="motivo_ausencia_escola" rows="3" autocomplete="off">{{ session['cadastro'].get('motivo_ausencia_escola', '') }}</textarea>
     </div>
     <div class="d-flex justify-content-between w-100">
         <button type="button" class="btn btn-secondary" id="btnVoltar" data-prev-url="{{ url_for('atendimento_etapa2') }}">Voltar</button>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -44,6 +44,10 @@
     <p class="mb-0">Formiguinhas Solidárias</p>
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    window.sessionCadastro = {{ session.get('cadastro', {}) | tojson | safe }};
+    console.log('Estado atual da sessão:', window.sessionCadastro);
+</script>
 {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure session state visible in all templates via base script
- log session data on every form submit
- prefill step 3 using session values
- adjust step 3 JS to respect saved data

## Testing
- `pytest -q` *(fails: TypeError quote_from_bytes expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_685544d6eb7c83208dd314c3dc531789