### PR TITLE
Implement upsert by familia_id

### DIFF
--- a/app/routes/composicao_familiar.py
+++ b/app/routes/composicao_familiar.py
@@ -59,3 +59,18 @@ def deletar_composicao(composicao_id):
     db.session.delete(composicao)
     db.session.commit()
     return jsonify({"mensagem": "Composicao deletada com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_composicao_familiar_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = ComposicaoFamiliar.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        composicao = composicao_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        composicao = composicao_schema.load(data)
+        db.session.add(composicao)
+    db.session.commit()
+    return composicao_schema.jsonify(composicao)

--- a/app/routes/condicoes_moradia.py
+++ b/app/routes/condicoes_moradia.py
@@ -59,3 +59,18 @@ def deletar_condicao_moradia(moradia_id):
     db.session.delete(condicao)
     db.session.commit()
     return jsonify({"mensagem": "Condição de moradia deletada com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_condicao_moradia_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = CondicaoMoradia.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        condicao = condicao_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        condicao = condicao_schema.load(data)
+        db.session.add(condicao)
+    db.session.commit()
+    return condicao_schema.jsonify(condicao)

--- a/app/routes/contato.py
+++ b/app/routes/contato.py
@@ -50,6 +50,21 @@ def atualizar_contato(contato_id):
     return contato_schema.jsonify(contato)
 
 
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_contato_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = Contato.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        contato = contato_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        contato = contato_schema.load(data)
+        db.session.add(contato)
+    db.session.commit()
+    return contato_schema.jsonify(contato)
+
+
 @bp.route("/<int:contato_id>", methods=["DELETE"])
 def deletar_contato(contato_id):
     contato = db.session.get(Contato, contato_id)

--- a/app/routes/educacao_entrevistado.py
+++ b/app/routes/educacao_entrevistado.py
@@ -59,3 +59,18 @@ def deletar_educacao(educacao_id):
     db.session.delete(educacao)
     db.session.commit()
     return jsonify({"mensagem": "Educação do entrevistado deletada com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_educacao_entrevistado_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = EducacaoEntrevistado.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        educacao = educacao_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        educacao = educacao_schema.load(data)
+        db.session.add(educacao)
+    db.session.commit()
+    return educacao_schema.jsonify(educacao)

--- a/app/routes/emprego_provedor.py
+++ b/app/routes/emprego_provedor.py
@@ -54,3 +54,18 @@ def deletar_emprego(emprego_id):
     db.session.delete(emprego)
     db.session.commit()
     return jsonify({"mensagem": "Emprego provedor deletado com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_emprego_provedor_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = EmpregoProvedor.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        emprego = emprego_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        emprego = emprego_schema.load(data)
+        db.session.add(emprego)
+    db.session.commit()
+    return emprego_schema.jsonify(emprego)

--- a/app/routes/endereco.py
+++ b/app/routes/endereco.py
@@ -54,3 +54,18 @@ def deletar_endereco(endereco_id):
     db.session.delete(endereco)
     db.session.commit()
     return jsonify({"mensagem": "Endereço deletado com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_endereco_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = Endereco.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        endereco = endereco_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        endereco = endereco_schema.load(data)
+        db.session.add(endereco)
+    db.session.commit()
+    return endereco_schema.jsonify(endereco)

--- a/app/routes/familia.py
+++ b/app/routes/familia.py
@@ -45,6 +45,21 @@ def atualizar_familia(familia_id):
     db.session.commit()
     return familia_schema.jsonify(familia)
 
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_familia_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = db.session.get(Familia, familia_id)
+    if existente:
+        familia = familia_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        familia = familia_schema.load(data)
+        db.session.add(familia)
+    db.session.commit()
+    return familia_schema.jsonify(familia)
+
 @bp.route("/<int:familia_id>", methods=["DELETE"])
 def deletar_familia(familia_id):
     familia = db.session.get(Familia, familia_id)

--- a/app/routes/renda_familiar.py
+++ b/app/routes/renda_familiar.py
@@ -54,3 +54,18 @@ def deletar_renda(renda_id):
     db.session.delete(renda)
     db.session.commit()
     return jsonify({"mensagem": "Renda familiar deletada com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_renda_familiar_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = RendaFamiliar.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        renda = renda_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        renda = renda_schema.load(data)
+        db.session.add(renda)
+    db.session.commit()
+    return renda_schema.jsonify(renda)

--- a/app/routes/saude_familiar.py
+++ b/app/routes/saude_familiar.py
@@ -54,3 +54,18 @@ def deletar_saude(saude_id):
     db.session.delete(saude)
     db.session.commit()
     return jsonify({"mensagem": "Saude familiar deletada com sucesso"}), 200
+
+
+@bp.route("/upsert/familia/<int:familia_id>", methods=["PUT"])
+def upsert_saude_familiar_por_familia(familia_id):
+    """Rota de upsert (criação ou atualização baseada em familia_id)."""
+    data = request.get_json()
+    existente = SaudeFamiliar.query.filter_by(familia_id=familia_id).first()
+    if existente:
+        saude = saude_schema.load(data, instance=existente, partial=True)
+    else:
+        data["familia_id"] = familia_id
+        saude = saude_schema.load(data)
+        db.session.add(saude)
+    db.session.commit()
+    return saude_schema.jsonify(saude)


### PR DESCRIPTION
## Summary
- add `upsert` endpoints to support PUT upsert logic based on `familia_id`
- handle create or update for all resources

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68555f8a07b4832095f8f21bfb5ba079