### PR TITLE
Implement etapa2 persistence

### DIFF
--- a/app/static/js/etapa2_endereco.js
+++ b/app/static/js/etapa2_endereco.js
@@ -2,6 +2,15 @@
 
 document.addEventListener('DOMContentLoaded', function() {
     console.log('Estado atual da sessão:', window.sessionCadastro);
+    const hiddenIdInput = document.getElementById('familia_id_hidden');
+    if (window.sessionFamiliaId === null) {
+        sessionStorage.removeItem('familia_id');
+        if (hiddenIdInput) hiddenIdInput.value = '';
+    } else if (window.sessionFamiliaId) {
+        sessionStorage.setItem('familia_id', window.sessionFamiliaId);
+        if (hiddenIdInput) hiddenIdInput.value = window.sessionFamiliaId;
+    }
+
     const cepInput = document.getElementById('cep');
     const manualCheckbox = document.getElementById('preenchimento_manual');
     const cepFeedback = document.getElementById('cep-feedback');
@@ -79,14 +88,45 @@ document.addEventListener('DOMContentLoaded', function() {
     const btnProxima = document.getElementById('btnProxima');
     const form = document.getElementById('formEtapa2');
     if (btnProxima && form) {
-        btnProxima.addEventListener('click', function() {
-            console.log('Dados do formulário etapa 2:', Object.fromEntries(new FormData(form).entries()));
-            console.log('Estado atual da sessão:', window.sessionCadastro);
+        btnProxima.addEventListener('click', async function (e) {
+            e.preventDefault();
+
             const nextUrl = btnProxima.getAttribute('data-next-url');
-            if (nextUrl) {
-                form.action = nextUrl;
-                form.method = 'post';
-                form.submit();
+            const dadosFormulario = Object.fromEntries(new FormData(form).entries());
+
+            if (dadosFormulario.preenchimento_manual !== undefined) {
+                dadosFormulario.preenchimento_manual =
+                    dadosFormulario.preenchimento_manual === 'on' || dadosFormulario.preenchimento_manual === true;
+            }
+
+            const storedFamiliaId = sessionStorage.getItem('familia_id');
+            const familiaId = storedFamiliaId !== null ? storedFamiliaId : window.sessionFamiliaId || '0';
+
+            btnProxima.disabled = true;
+
+            try {
+                const resposta = await fetch(`/enderecos/upsert/familia/${familiaId}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(dadosFormulario)
+                });
+
+                if (resposta.ok) {
+                    if (nextUrl) {
+                        form.action = nextUrl;
+                        form.method = 'post';
+                        form.submit();
+                    }
+                } else {
+                    const erro = await resposta.json().catch(() => ({ mensagem: 'Erro desconhecido' }));
+                    alert(JSON.stringify(erro));
+                    btnProxima.disabled = false;
+                }
+            } catch (err) {
+                alert('Erro ao enviar os dados. Tente novamente.');
+                btnProxima.disabled = false;
             }
         });
     }

--- a/app/templates/atendimento/etapa2_endereco.html
+++ b/app/templates/atendimento/etapa2_endereco.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-4 text-center">Etapa 2 de 10 - Endereço da família</h2>
 <form id="formEtapa2" autocomplete="off" class="form-endereco-grid" method="post">
+    <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
 
     <!-- Checkbox -->
     <div class="endereco-full">


### PR DESCRIPTION
## Summary
- add hidden familia_id to etapa2 form
- persist address data via `/enderecos/upsert/familia/<id>` when proceeding to the next step

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_685588f9fb348320800c55f88e35e3ff