### PR TITLE
Implement data persistence for step 4

### DIFF
--- a/app/templates/atendimento/etapa4_contato.html
+++ b/app/templates/atendimento/etapa4_contato.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-4 text-center">Etapa 4 de 10 - Informações de contato da família</h2>
 <form id="formEtapa4" autocomplete="off" method="post">
+    <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="row align-items-end mb-3">
         <div class="col-md-6">
             <label for="telefone_principal" class="form-label">Celular principal para contato</label>


### PR DESCRIPTION
## Summary
- sync familia_id with DOM for Etapa 4 form
- persist contato data before moving to the next step

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68559a2fb91c8320b3887fb6ea85c38b