### PR TITLE
Enable persistence in step 6

### DIFF
--- a/app/templates/atendimento/etapa6_saude_familiar.html
+++ b/app/templates/atendimento/etapa6_saude_familiar.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-4 text-center">Etapa 6 de 10 - Saúde dos membros da família</h2>
 <form id="formEtapa6" autocomplete="off" method="post">
+    <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">
         <label class="form-label">Algum morador possui alguma doença crônica?</label>
         <div>


### PR DESCRIPTION
## Summary
- add `familia_id` hidden input to etapa6
- sync the stored familia ID on page load
- persist etapa6 via `/saude_familiar/upsert/familia/<id>` before advancing

## Testing
- `pytest -q` *(fails: TypeError: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_6855a2127dd08320a769767b6755442f