### PR TITLE
Implement etapa 9 persistence

### DIFF
--- a/app/static/js/etapa9_escolaridade.js
+++ b/app/static/js/etapa9_escolaridade.js
@@ -2,6 +2,16 @@
 
 document.addEventListener('DOMContentLoaded', function() {
     console.log('Estado atual da sessão:', window.sessionCadastro);
+
+    const hiddenIdInput = document.getElementById('familia_id_hidden');
+    if (window.sessionFamiliaId === null) {
+        sessionStorage.removeItem('familia_id');
+        if (hiddenIdInput) hiddenIdInput.value = '';
+    } else if (window.sessionFamiliaId) {
+        sessionStorage.setItem('familia_id', window.sessionFamiliaId);
+        if (hiddenIdInput) hiddenIdInput.value = window.sessionFamiliaId;
+    }
+
     const estudaSim = document.getElementById('estuda_sim');
     const estudaNao = document.getElementById('estuda_nao');
     const cursoContainer = document.getElementById('curso_ou_serie_atual_container');
@@ -25,14 +35,54 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleCurso();
 
     if (btnProxima && form) {
-        btnProxima.addEventListener('click', function() {
-            console.log('Dados do formulário etapa 9:', Object.fromEntries(new FormData(form).entries()));
-            console.log('Estado atual da sessão:', window.sessionCadastro);
+        btnProxima.addEventListener('click', async function(e) {
+            e.preventDefault();
+
             const nextUrl = btnProxima.getAttribute('data-next-url');
-            if (nextUrl) {
-                form.action = nextUrl;
-                form.method = 'post';
-                form.submit();
+            const dadosFormulario = Object.fromEntries(new FormData(form).entries());
+
+            const storedFamiliaId = sessionStorage.getItem('familia_id');
+            const familiaId = storedFamiliaId !== null ? storedFamiliaId : window.sessionFamiliaId || '0';
+
+            btnProxima.disabled = true;
+
+            try {
+                const resposta = await fetch(`/educacao_entrevistado/upsert/familia/${familiaId}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(dadosFormulario)
+                });
+
+                if (resposta.ok) {
+                    const respFamilia = await fetch(`/familias/upsert/familia/${familiaId}`, {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ status_cadastro: 'finalizado' })
+                    });
+
+                    if (respFamilia.ok) {
+                        if (nextUrl) {
+                            form.action = nextUrl;
+                            form.method = 'post';
+                            form.submit();
+                        }
+                    } else {
+                        const erro = await respFamilia.json().catch(() => ({ mensagem: 'Erro desconhecido' }));
+                        alert(JSON.stringify(erro));
+                        btnProxima.disabled = false;
+                    }
+                } else {
+                    const erro = await resposta.json().catch(() => ({ mensagem: 'Erro desconhecido' }));
+                    alert(JSON.stringify(erro));
+                    btnProxima.disabled = false;
+                }
+            } catch (err) {
+                alert('Erro ao enviar os dados. Tente novamente.');
+                btnProxima.disabled = false;
             }
         });
     }

--- a/app/templates/atendimento/etapa9_escolaridade.html
+++ b/app/templates/atendimento/etapa9_escolaridade.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-4 text-center">Etapa 9 de 10 - Escolaridade do(a) entrevistado(a)</h2>
 <form id="formEtapa9" autocomplete="off" method="post">
+    <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">
         <label for="nivel_escolaridade" class="form-label">Qual é o nível de escolaridade da pessoa entrevistada?</label>
         <select class="form-select" id="nivel_escolaridade" name="nivel_escolaridade" autocomplete="off">


### PR DESCRIPTION
## Summary
- add hidden familia_id input in etapa 9 template
- implement etapa9_escolaridade.js logic to save data to backend and mark family as finalized

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_6855a99dbe9083209809ac7c1b4827b8