### PR TITLE
Add progress bar timeline

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,20 @@ from app import create_app
 
 app = create_app()
 
+ETAPAS = [
+    "dados pessoais",
+    "endereço",
+    "composição familiar",
+    "contatos",
+    "condições habitação",
+    "saúde familiar",
+    "emprego",
+    "renda familiar",
+    "educação",
+    "outras necessidades",
+    "encerramento",
+]
+
 
 def reset_atendimento_sessao():
     """Remove informações de atendimento da sessão."""
@@ -62,7 +76,11 @@ def atendimento_etapa1():
         if form_data.get("familia_id"):
             session["familia_id"] = form_data["familia_id"]
         return redirect(url_for("atendimento_etapa2"))
-    return render_template("atendimento/etapa1_dados_pessoais.html")
+    return render_template(
+        "atendimento/etapa1_dados_pessoais.html",
+        etapa_atual=1,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa2", methods=["GET", "POST"])
@@ -73,7 +91,11 @@ def atendimento_etapa2():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa3"))
-    return render_template("atendimento/etapa2_endereco.html")
+    return render_template(
+        "atendimento/etapa2_endereco.html",
+        etapa_atual=2,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa3", methods=["GET", "POST"])
@@ -84,7 +106,11 @@ def atendimento_etapa3():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa4"))
-    return render_template("atendimento/etapa3_composicao_familiar.html")
+    return render_template(
+        "atendimento/etapa3_composicao_familiar.html",
+        etapa_atual=3,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa4", methods=["GET", "POST"])
@@ -95,7 +121,11 @@ def atendimento_etapa4():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa5"))
-    return render_template("atendimento/etapa4_contato.html")
+    return render_template(
+        "atendimento/etapa4_contato.html",
+        etapa_atual=4,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa5", methods=["GET", "POST"])
@@ -106,7 +136,11 @@ def atendimento_etapa5():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa6"))
-    return render_template("atendimento/etapa5_condicoes_habitacionais.html")
+    return render_template(
+        "atendimento/etapa5_condicoes_habitacionais.html",
+        etapa_atual=5,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa6", methods=["GET", "POST"])
@@ -117,7 +151,11 @@ def atendimento_etapa6():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa7"))
-    return render_template("atendimento/etapa6_saude_familiar.html")
+    return render_template(
+        "atendimento/etapa6_saude_familiar.html",
+        etapa_atual=6,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa7", methods=["GET", "POST"])
@@ -128,7 +166,11 @@ def atendimento_etapa7():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa8"))
-    return render_template("atendimento/etapa7_emprego_e_habilidades.html")
+    return render_template(
+        "atendimento/etapa7_emprego_e_habilidades.html",
+        etapa_atual=7,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa8", methods=["GET", "POST"])
@@ -139,7 +181,11 @@ def atendimento_etapa8():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa9"))
-    return render_template("atendimento/etapa8_renda_e_gastos.html")
+    return render_template(
+        "atendimento/etapa8_renda_e_gastos.html",
+        etapa_atual=8,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa9", methods=["GET", "POST"])
@@ -150,7 +196,11 @@ def atendimento_etapa9():
         cadastro.update(request.form.to_dict(flat=True))
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa10"))
-    return render_template("atendimento/etapa9_escolaridade.html")
+    return render_template(
+        "atendimento/etapa9_escolaridade.html",
+        etapa_atual=9,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa10", methods=["GET", "POST"])
@@ -167,7 +217,11 @@ def atendimento_etapa10():
                 cadastro["demandas"] = []
         session["cadastro"] = cadastro
         return redirect(url_for("atendimento_etapa11"))
-    return render_template("atendimento/etapa10_outras_necessidades.html")
+    return render_template(
+        "atendimento/etapa10_outras_necessidades.html",
+        etapa_atual=10,
+        etapas=ETAPAS,
+    )
 
 
 @app.route("/atendimento/etapa11", methods=["GET", "POST"])
@@ -179,7 +233,11 @@ def atendimento_etapa11():
         session["cadastro"] = cadastro
         reset_atendimento_sessao()
         return redirect(url_for("home"))
-    return render_template("atendimento/etapa11_atendimento.html")
+    return render_template(
+        "atendimento/etapa11_atendimento.html",
+        etapa_atual=11,
+        etapas=ETAPAS,
+    )
 
 
 if __name__ == "__main__":

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -296,3 +296,76 @@ h1, h2, h3, h4, h5, h6 {
         flex: 1 1 100%;
     }
 }
+
+/* Timeline de etapas */
+.timeline-container {
+    overflow-x: auto;
+    padding-bottom: 1rem;
+}
+
+.timeline {
+    display: flex;
+    position: relative;
+    margin: 0;
+    padding: 0;
+    width: max-content;
+}
+
+.timeline-item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 0 0 auto;
+    padding: 0 1rem;
+    min-width: 80px;
+    text-align: center;
+}
+
+.timeline-item:not(:last-child)::after {
+    content: "";
+    position: absolute;
+    top: 18px;
+    left: calc(50% + 18px);
+    width: calc(100% - 36px);
+    height: 2px;
+    background: #dee2e6;
+    z-index: 1;
+}
+
+.timeline-item.complete:not(:last-child)::after {
+    background: #28a745;
+}
+
+.timeline-item.active:not(:last-child)::after {
+    background: var(--primary-color);
+}
+
+.circle {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #dee2e6;
+    color: #6c757d;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 500;
+    z-index: 2;
+}
+
+.timeline-item.complete .circle {
+    background: #28a745;
+    color: #fff;
+}
+
+.timeline-item.active .circle {
+    background: var(--primary-color);
+    color: #fff;
+}
+
+.timeline-label {
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+}
+

--- a/app/templates/atendimento/etapa10_outras_necessidades.html
+++ b/app/templates/atendimento/etapa10_outras_necessidades.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 10{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 10 de 11 - Outras necessidades informadas</h2>
+{% include 'components/progress_bar_etapas.html' %}
 
 <p class="text-muted mb-4">
     Registre abaixo outras necessidades identificadas durante o atendimento. 

--- a/app/templates/atendimento/etapa11_atendimento.html
+++ b/app/templates/atendimento/etapa11_atendimento.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 11{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 11 de 11 - Conclusão do atendimento</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa11" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/atendimento/etapa1_dados_pessoais.html
+++ b/app/templates/atendimento/etapa1_dados_pessoais.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 1{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 1 de 11 - Informações pessoais do(a) entrevistado(a)</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa1" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/atendimento/etapa2_endereco.html
+++ b/app/templates/atendimento/etapa2_endereco.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 2{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 2 de 11 - Endereço da família</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa2" autocomplete="off" class="form-endereco-grid" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
 

--- a/app/templates/atendimento/etapa3_composicao_familiar.html
+++ b/app/templates/atendimento/etapa3_composicao_familiar.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 3{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 3 de 11 - Composição familiar</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa3" autocomplete="off">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3 campo-numerico">

--- a/app/templates/atendimento/etapa4_contato.html
+++ b/app/templates/atendimento/etapa4_contato.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 4{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 4 de 11 - Informações de contato da família</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa4" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="row align-items-end mb-3">

--- a/app/templates/atendimento/etapa5_condicoes_habitacionais.html
+++ b/app/templates/atendimento/etapa5_condicoes_habitacionais.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 5{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 5 de 11 - Condições habitacionais da família</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa5" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/atendimento/etapa6_saude_familiar.html
+++ b/app/templates/atendimento/etapa6_saude_familiar.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 6{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 6 de 11 - Saúde dos membros da família</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa6" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/atendimento/etapa7_emprego_e_habilidades.html
+++ b/app/templates/atendimento/etapa7_emprego_e_habilidades.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 7{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 7 de 11 - Emprego do provedor principal</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa7" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/atendimento/etapa8_renda_e_gastos.html
+++ b/app/templates/atendimento/etapa8_renda_e_gastos.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 8{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 8 de 11 - Renda e gastos mensais da família</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa8" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/atendimento/etapa9_escolaridade.html
+++ b/app/templates/atendimento/etapa9_escolaridade.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Atendimento à Família - Etapa 9{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Etapa 9 de 11 - Escolaridade do(a) entrevistado(a)</h2>
+{% include 'components/progress_bar_etapas.html' %}
 <form id="formEtapa9" autocomplete="off" method="post">
     <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
     <div class="mb-3">

--- a/app/templates/components/progress_bar_etapas.html
+++ b/app/templates/components/progress_bar_etapas.html
@@ -1,0 +1,11 @@
+<div class="timeline-container mb-4">
+    <ul class="timeline list-unstyled">
+        {% for nome in etapas %}
+        {% set num = loop.index %}
+        <li class="timeline-item {% if num == etapa_atual %}active{% elif num < etapa_atual %}complete{% endif %}">
+            <div class="circle">{{ num }}</div>
+            <div class="timeline-label">{{ nome }}</div>
+        </li>
+        {% endfor %}
+    </ul>
+</div>


### PR DESCRIPTION
## Summary
- implement progress bar component for atendimento timeline
- style timeline in global CSS
- include component in each atendimento etapa template
- expose `ETAPAS` constant and pass `etapa_atual`/`etapas` to templates

## Testing
- `pytest -q` *(fails: TypeError quote_from_bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68593d1d3dcc8320a3af62d1865c7f2a