### PR TITLE
Improve etapa0_menu layout with modal search

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -369,3 +369,380 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 0.8rem;
 }
 
+/* Menu de Atendimento - Botões */
+.menu-buttons-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    max-width: 500px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+}
+
+.menu-btn {
+    display: flex !important;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 120px;
+    padding: 1.5rem 2rem;
+    border-radius: 16px;
+    text-decoration: none;
+    box-shadow: var(--shadow-md);
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+    border: none;
+    font-weight: 500;
+}
+
+.menu-btn i {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+    transition: transform 0.3s ease;
+}
+
+.menu-btn span {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    line-height: 1.2;
+}
+
+.menu-btn small {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    line-height: 1.1;
+}
+
+.menu-btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+    text-decoration: none;
+}
+
+.menu-btn:hover i {
+    transform: scale(1.1);
+}
+
+.menu-btn:active {
+    transform: translateY(-1px);
+}
+
+/* Cores específicas para cada botão */
+.menu-btn.btn-primary {
+    background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
+    color: white;
+}
+
+.menu-btn.btn-primary:hover {
+    background: linear-gradient(135deg, #0056b3 0%, #004085 100%);
+    color: white;
+}
+
+.menu-btn.btn-success {
+    background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%);
+    color: white;
+}
+
+.menu-btn.btn-success:hover {
+    background: linear-gradient(135deg, #1e7e34 0%, #155724 100%);
+    color: white;
+}
+
+.menu-btn.btn-warning {
+    background: linear-gradient(135deg, #ffc107 0%, #e0a800 100%);
+    color: #212529;
+}
+
+.menu-btn.btn-warning:hover {
+    background: linear-gradient(135deg, #e0a800 0%, #d39e00 100%);
+    color: #212529;
+}
+
+/* Responsividade para botões do menu */
+@media (max-width: 768px) {
+    .menu-buttons-container {
+        padding: 1rem 0.5rem;
+        gap: 1rem;
+    }
+    
+    .menu-btn {
+        min-height: 100px;
+        padding: 1.25rem 1.5rem;
+    }
+    
+    .menu-btn i {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+    }
+    
+    .menu-btn span {
+        font-size: 1rem;
+    }
+    
+    .menu-btn small {
+        font-size: 0.8rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .menu-btn {
+        min-height: 90px;
+        padding: 1rem;
+    }
+    
+    .menu-btn i {
+        font-size: 1.75rem;
+    }
+    
+    .menu-btn span {
+        font-size: 0.95rem;
+    }
+}
+
+/* Container de busca de família */
+.search-container {
+    background-color: rgba(255, 255, 255, 0.95);
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: var(--shadow-md);
+}
+
+.search-container .form-control {
+    border-radius: 10px;
+    border: 2px solid rgba(0, 0, 0, 0.1);
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+}
+
+.search-container .form-control:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.15);
+}
+
+.search-container .list-group-item {
+    border-radius: 8px;
+    margin-bottom: 0.5rem;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    transition: var(--transition-base);
+}
+
+.search-container .list-group-item:hover {
+    background-color: rgba(0, 123, 255, 0.05);
+    border-color: var(--primary-color);
+    cursor: pointer;
+}
+
+/* Modal de Busca de Família */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.3s ease-out;
+}
+
+.modal-overlay.d-none {
+    display: none !important;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+    width: 90%;
+    max-width: 600px;
+    max-height: 80vh;
+    overflow-y: auto;
+    animation: slideIn 0.3s ease-out;
+    position: relative;
+}
+
+.modal-header {
+    padding: 1.5rem 2rem 1rem;
+    border-bottom: 2px solid rgba(0, 0, 0, 0.05);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.modal-title {
+    color: var(--text-color);
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.modal-title i {
+    color: var(--primary-color);
+}
+
+.btn-close {
+    background: none;
+    border: none;
+    font-size: 1.25rem;
+    color: #6c757d;
+    cursor: pointer;
+    padding: 0.5rem;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition-base);
+}
+
+.btn-close:hover {
+    background-color: rgba(220, 53, 69, 0.1);
+    color: #dc3545;
+}
+
+.modal-body {
+    padding: 1.5rem 2rem 2rem;
+}
+
+.search-instruction {
+    background: linear-gradient(135deg, rgba(0, 123, 255, 0.1) 0%, rgba(0, 123, 255, 0.05) 100%);
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    border-left: 4px solid var(--primary-color);
+}
+
+.search-instruction i {
+    color: var(--primary-color);
+    font-size: 1.1rem;
+}
+
+.search-instruction span {
+    color: var(--text-color);
+    font-weight: 500;
+    font-size: 1rem;
+}
+
+.search-input-group {
+    display: flex;
+    gap: 0.75rem;
+    align-items: stretch;
+}
+
+.search-input-group .form-control {
+    flex: 1;
+    border-radius: 10px;
+    border: 2px solid rgba(0, 0, 0, 0.1);
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    transition: var(--transition-base);
+}
+
+.search-input-group .form-control:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.15);
+}
+
+.search-input-group .btn {
+    border-radius: 10px;
+    padding: 0.75rem 1.5rem;
+    font-weight: 600;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+#resultadosContainer {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+#resultadosContainer .list-group-item {
+    border-radius: 10px;
+    margin-bottom: 0.5rem;
+    border: 2px solid rgba(0, 0, 0, 0.05);
+    transition: var(--transition-base);
+    cursor: pointer;
+    padding: 1rem;
+}
+
+#resultadosContainer .list-group-item:hover {
+    background-color: rgba(0, 123, 255, 0.05);
+    border-color: var(--primary-color);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-sm);
+}
+
+#resultadosContainer .list-group-item:active {
+    transform: translateY(0);
+}
+
+#loadingSearch {
+    color: var(--text-color);
+}
+
+#loadingSearch .spinner-border {
+    width: 2rem;
+    height: 2rem;
+}
+
+/* Animações */
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-30px) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Responsividade do modal */
+@media (max-width: 768px) {
+    .modal-content {
+        width: 95%;
+        margin: 1rem;
+    }
+    
+    .modal-header,
+    .modal-body {
+        padding: 1rem 1.5rem;
+    }
+    
+    .search-input-group {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+    
+    .search-input-group .btn {
+        width: 100%;
+        justify-content: center;
+    }
+}
+

--- a/app/static/js/menu_busca_familia.js
+++ b/app/static/js/menu_busca_familia.js
@@ -1,57 +1,34 @@
-// JS para buscar famílias existentes
-
 document.addEventListener('DOMContentLoaded', function () {
     const btn = document.getElementById('btnAtenderFamilia');
-    const container = document.getElementById('buscaFamiliaContainer');
+    const modal = document.getElementById('buscaFamiliaModal');
+    const closeBtn = document.getElementById('fecharBuscaFamilia');
     const input = document.getElementById('buscaFamiliaInput');
-    const lista = document.getElementById('buscaFamiliaResultados');
-    let timer = null;
 
-    if (!btn) return;
-
-    btn.addEventListener('click', function (e) {
-        e.preventDefault();
-        if (container.classList.contains('d-none')) {
-            container.classList.remove('d-none');
-            input.focus();
-        } else {
-            container.classList.add('d-none');
-            lista.innerHTML = '';
-            input.value = '';
+    function abrirModal() {
+        if (modal) {
+            modal.classList.remove('d-none');
+            if (input) input.focus();
         }
-    });
+    }
 
-    input.addEventListener('input', function () {
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(async () => {
-            const termo = input.value.trim();
-            if (termo.length < 2) {
-                lista.innerHTML = '';
-                return;
-            }
-            try {
-                const resp = await fetch(`/familias/busca?q=${encodeURIComponent(termo)}`);
-                if (resp.ok) {
-                    const dados = await resp.json();
-                    lista.innerHTML = '';
-                    if (dados.length === 0) {
-                        const li = document.createElement('li');
-                        li.className = 'list-group-item';
-                        li.textContent = 'Nenhuma família encontrada';
-                        lista.appendChild(li);
-                    } else {
-                        dados.forEach(f => {
-                            const li = document.createElement('li');
-                            li.className = 'list-group-item';
-                            const ultima = f.ultimo_atendimento ? ` - Último atendimento em ${f.ultimo_atendimento}` : '';
-                            li.innerHTML = `<a href="/atendimento_familia/${f.familia_id}" class="text-decoration-none">${f.nome_responsavel} - ${f.cpf || ''} - ${f.data_nascimento || ''}${ultima}</a>`;
-                            lista.appendChild(li);
-                        });
-                    }
-                }
-            } catch (err) {
-                console.error(err);
-            }
-        }, 300);
-    });
+    function fecharModal() {
+        if (modal) {
+            modal.classList.add('d-none');
+        }
+    }
+
+    if (btn) {
+        btn.addEventListener('click', function (e) {
+            e.preventDefault();
+            abrirModal();
+        });
+    }
+
+    if (closeBtn) {
+        closeBtn.addEventListener('click', fecharModal);
+    }
+
+    if (window.autoOpenBuscaFamilia) {
+        abrirModal();
+    }
 });

--- a/app/templates/atendimento/etapa0_menu.html
+++ b/app/templates/atendimento/etapa0_menu.html
@@ -2,18 +2,62 @@
 {% block title %}Atendimento à Família - Menu{% endblock %}
 {% block content %}
 <h2 class="mb-4 text-center">Menu de Atendimento</h2>
-<div class="d-flex flex-column align-items-center gap-3">
-    <a href="#" id="btnAtenderFamilia" class="btn btn-primary">Atender família</a>
-    <a href="{{ url_for('atendimento_nova_familia') }}" id="btnNovaFamilia" class="btn btn-success">Registrar nova família</a>
-    <a href="{{ url_for('retomar_atendimento') }}" class="btn btn-secondary">Retomar atendimento em andamento</a>
-</div>
-<div id="buscaFamiliaContainer" class="mt-3 d-none" style="max-width:400px;margin:0 auto;">
-    <input type="text" id="buscaFamiliaInput" class="form-control" placeholder="Digite nome ou CPF">
-    <ul id="buscaFamiliaResultados" class="list-group mt-2"></ul>
+<div class="menu-buttons-container">
+    <a href="#" id="btnAtenderFamilia" class="menu-btn btn btn-primary">
+        <i class="fa-solid fa-search"></i>
+        <span>Atender família</span>
+        <small>Buscar cadastro existente</small>
+    </a>
+    <a href="{{ url_for('atendimento_nova_familia') }}" id="btnNovaFamilia" class="menu-btn btn btn-success">
+        <i class="fa-solid fa-user-plus"></i>
+        <span>Registrar nova família</span>
+        <small>Iniciar um novo cadastro</small>
+    </a>
+    <a href="{{ url_for('retomar_atendimento') }}" class="menu-btn btn btn-warning">
+        <i class="fa-solid fa-play"></i>
+        <span>Retomar atendimento</span>
+        <small>Continuar cadastro em andamento</small>
+    </a>
 </div>
 {% if error_msg %}
 <div id="retomar-feedback" class="invalid-feedback d-block text-center mt-3">{{ error_msg }}</div>
 {% endif %}
+
+<div id="buscaFamiliaModal" class="modal-overlay d-none">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h5 class="modal-title"><i class="fa-solid fa-search"></i> Buscar família</h5>
+            <button type="button" class="btn-close" id="fecharBuscaFamilia">&times;</button>
+        </div>
+        <div class="modal-body">
+            <div class="search-instruction">
+                <i class="fa-solid fa-info-circle"></i>
+                <span>Digite parte do nome ou CPF e clique em Buscar.</span>
+            </div>
+            <form method="get" class="search-input-group">
+                <input type="text" name="q" id="buscaFamiliaInput" class="form-control" placeholder="Digite nome ou CPF" value="{{ request.args.get('q','') }}">
+                <button type="submit" class="btn btn-primary"><i class="fa-solid fa-search"></i> Buscar</button>
+            </form>
+            {% if resultados is not none %}
+            <div id="resultadosContainer" class="mt-3">
+                <ul class="list-group">
+                    {% if resultados %}
+                        {% for f in resultados %}
+                        <li class="list-group-item">
+                            <a href="{{ url_for('atendimento_familia', familia_id=f.familia_id) }}" class="text-decoration-none">
+                                {{ f.nome_responsavel }} - {{ f.cpf or '' }} - {{ f.data_nascimento or '' }}{% if f.ultimo_atendimento %} - Último atendimento em {{ f.ultimo_atendimento }}{% endif %}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    {% else %}
+                        <li class="list-group-item">Nenhuma família encontrada</li>
+                    {% endif %}
+                </ul>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -24,7 +68,7 @@
             sessionStorage.removeItem('familia_id');
         });
     }
+    window.autoOpenBuscaFamilia = {{ auto_open|tojson }};
 </script>
 <script src="{{ url_for('static', filename='js/menu_busca_familia.js') }}"></script>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- rework atendimento menu to use styled buttons and modal search
- replicate reference CSS for menu and modal
- update menu search JavaScript to open/close modal
- handle search server-side without AJAX

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fff1a7da0832086e05049afef488f