### PR TITLE
Add active demand section with edit modal

### DIFF
--- a/app/static/css/etapa10_outras_necessidades.css
+++ b/app/static/css/etapa10_outras_necessidades.css
@@ -45,4 +45,27 @@ select.prioridade:has(option[value="Baixa"]:checked) {
     margin-bottom: 1.5rem;
 }
 
+/* Tabela de demandas ativas */
+#tabelaDemandasAtivas th,
+#tabelaDemandasAtivas td {
+    vertical-align: middle;
+}
+
+#tabelaDemandasAtivas td .btn {
+    padding: 0.25rem 0.5rem;
+}
+
+#tabelaDemandasAtivas .prioridade-alta {
+    color: #b30000;
+    font-weight: 600;
+}
+#tabelaDemandasAtivas .prioridade-media {
+    color: #d47300;
+    font-weight: 600;
+}
+#tabelaDemandasAtivas .prioridade-baixa {
+    color: #1f7a1f;
+    font-weight: 600;
+}
+
 

--- a/app/templates/atendimento/etapa10_outras_necessidades.html
+++ b/app/templates/atendimento/etapa10_outras_necessidades.html
@@ -3,8 +3,27 @@
 {% block content %}
 {% include 'components/progress_bar_etapas.html' %}
 
+<div id="demandasAtivasSection" class="mb-4 d-none">
+    <h4 class="mb-3">Demandas ativas</h4>
+    <div class="table-responsive">
+        <table id="tabelaDemandasAtivas" class="table table-striped align-middle">
+            <thead>
+                <tr>
+                    <th>Descrição</th>
+                    <th>Categoria</th>
+                    <th>Prioridade</th>
+                    <th>Status atual</th>
+                    <th>Observação</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
 <p class="text-muted mb-4">
-    Registre abaixo outras necessidades identificadas durante o atendimento. 
+    Registre abaixo outras necessidades identificadas durante o atendimento.
 </p>
 
 <form id="formEtapa10" autocomplete="off" method="post">
@@ -24,6 +43,43 @@
         </button>
     </div>
 </form>
+
+<div id="modalAtualizarDemanda" class="modal-overlay d-none">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h5 class="modal-title"><i class="fa-solid fa-pen"></i> Atualizar demanda</h5>
+            <button type="button" class="btn-close" id="fecharModalDemanda">&times;</button>
+        </div>
+        <div class="modal-body">
+            <form id="formAtualizarDemanda">
+                <input type="hidden" id="modal_demanda_id">
+                <div class="mb-3">
+                    <label class="form-label">Demanda</label>
+                    <p id="modal_demanda_descricao" class="fw-bold mb-1"></p>
+                </div>
+                <div class="mb-3">
+                    <label for="modal_status" class="form-label">Status atual</label>
+                    <select id="modal_status" class="form-select" required>
+                        <option value="Em análise">Em análise</option>
+                        <option value="Em andamento">Em andamento</option>
+                        <option value="Encaminhada">Encaminhada</option>
+                        <option value="Aguardando resposta">Aguardando resposta</option>
+                        <option value="Suspensa">Suspensa</option>
+                        <option value="Cancelada">Cancelada</option>
+                        <option value="Concluída">Concluída</option>
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label for="modal_observacao" class="form-label">Observação</label>
+                    <textarea id="modal_observacao" class="form-control" rows="3"></textarea>
+                </div>
+                <div class="text-end">
+                    <button type="button" class="btn btn-primary" id="salvarAtualizacaoDemanda">Salvar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_css %}


### PR DESCRIPTION
## Summary
- show active demands loaded from session when available
- add elegant table for active demands with edit button
- provide modal for updating demand status
- style active demands table

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_686162ebce108320b9e2164f21e4080a