### PR TITLE
Improve expiration handling in user admin

### DIFF
--- a/app/static/js/admin_usuarios.js
+++ b/app/static/js/admin_usuarios.js
@@ -16,6 +16,9 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Tooltip para botões
     initializeTooltips();
+
+    // Desabilitar campo de expiração para administradores
+    toggleExpiresField();
 });
 
 function addStatusIndicators() {
@@ -231,6 +234,24 @@ function addAnimations() {
             this.style.transform = 'translateY(0) scale(1)';
         });
     });
+}
+
+function toggleExpiresField() {
+    const tipoSelect = document.getElementById('tipo');
+    const expiresInput = document.getElementById('expires_at');
+    if (!tipoSelect || !expiresInput) return;
+
+    function updateState() {
+        if (tipoSelect.value === 'admin') {
+            expiresInput.value = '';
+            expiresInput.setAttribute('disabled', 'disabled');
+        } else {
+            expiresInput.removeAttribute('disabled');
+        }
+    }
+
+    tipoSelect.addEventListener('change', updateState);
+    updateState();
 }
 
 function initializeTooltips() {

--- a/app/templates/admin/usuarios.html
+++ b/app/templates/admin/usuarios.html
@@ -52,7 +52,7 @@
                     </td>
                     <td>
                         {% if u.expires_at %}
-                            <span class="text-muted">{{ u.expires_at.strftime('%d/%m/%Y') }}</span>
+                            <span class="text-muted">{{ u.expires_at.strftime('%d/%m/%Y %H:%M') }}</span>
                         {% else %}
                             <span class="text-muted">—</span>
                         {% endif %}
@@ -137,7 +137,7 @@
                                 <i class="fas fa-calendar-times me-1"></i>
                                 Data de Expiração
                             </label>
-                            <input type="date" class="form-control" name="expires_at" id="expires_at">
+                            <input type="datetime-local" class="form-control" name="expires_at" id="expires_at">
                             <div class="form-text">Deixe vazio para nunca expirar</div>
                         </div>
                         <div class="col-md-6">


### PR DESCRIPTION
## Summary
- allow selecting expiration time using `datetime-local`
- disable expiration field for admin users via JS
- show date and time of expiration in user list

## Testing
- `pytest -q` *(fails: DB errors because SQL Server driver is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862c4d582d483209351183ba15d7ed7