### PR TITLE
Add debug logging to login

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, current_app
 from flask_jwt_extended import create_access_token
 from werkzeug.security import check_password_hash
 from datetime import datetime
@@ -12,16 +12,22 @@ bp = Blueprint('auth', __name__, url_prefix='')
 def login():
     if request.method == 'POST':
         data = request.get_json()
+        current_app.logger.debug('Dados recebidos para login: %s', data)
         login_ = data.get('login') if data else None
         senha = data.get('senha') if data else None
+        if not login_ or not senha:
+            current_app.logger.debug('Login ou senha não fornecidos')
         usuario = Usuario.query.filter_by(login=login_).first()
         if usuario and check_password_hash(usuario.senha_hash, senha):
             if usuario.tipo == 'temporario' and usuario.expires_at and usuario.expires_at < datetime.utcnow():
+                current_app.logger.debug('Conta expirada para usuário %s', login_)
                 return jsonify({'mensagem': 'Conta expirada'}), 401
             usuario.last_login_at = datetime.utcnow()
             db.session.commit()
             token = create_access_token(identity=usuario.id)
+            current_app.logger.debug('Login bem-sucedido para usuário %s', login_)
             return jsonify({'access_token': token})
+        current_app.logger.debug('Falha no login para usuário %s', login_)
         return jsonify({'mensagem': 'Credenciais inválidas'}), 401
     return render_template('login.html')
 

--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -32,6 +32,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const loginInput = document.getElementById('login');
             const senhaInput = document.getElementById('senha');
             if (!loginInput.value.trim() || !senhaInput.value.trim()) {
+                console.log('Login ou senha em branco, ignorando submit.');
                 return;
             }
             isSubmitting = true;
@@ -41,20 +42,25 @@ document.addEventListener('DOMContentLoaded', function() {
             if (span) span.textContent = 'Entrando...';
 
             try {
+                console.log('Enviando requisição de login...');
                 const resp = await fetch('/login', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ login: loginInput.value, senha: senhaInput.value })
                 });
+                console.log('Resposta recebida:', resp.status, resp.statusText);
                 if (resp.ok) {
                     const data = await resp.json();
+                    console.log('Token obtido:', data);
                     sessionStorage.setItem('access_token', data.access_token);
                     window.location.href = '/';
                 } else {
                     const erro = await resp.json().catch(() => ({ mensagem: 'Erro' }));
+                    console.error('Falha no login:', erro);
                     alert(erro.mensagem || 'Falha no login');
                 }
             } catch (err) {
+                console.error('Erro ao tentar login:', err);
                 alert('Erro ao conectar ao servidor.');
             }
             submitBtn.classList.remove('loading');


### PR DESCRIPTION
## Summary
- add console logs in login.js to expose fetch errors
- add backend debug logs when processing login requests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_jwt_extended')*


------
https://chatgpt.com/codex/tasks/task_e_6863b1b05d508320bf83eeb79def11c3