### PR TITLE
Fix JWT login by restoring Flask session

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,11 +1,20 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, current_app
 from flask_jwt_extended import create_access_token
+from flask_login import login_user, logout_user, current_user
 from werkzeug.security import check_password_hash
 from datetime import datetime
 from app.models.usuario import Usuario
 from app import db
 
 bp = Blueprint('auth', __name__, url_prefix='')
+
+
+@bp.before_app_request
+def check_expired_user():
+    if current_user.is_authenticated and current_user.tipo == 'temporario' and current_user.expires_at and current_user.expires_at < datetime.utcnow():
+        logout_user()
+        flash('Sessão expirada', 'danger')
+        return redirect(url_for('auth.login'))
 
 
 @bp.route('/login', methods=['GET', 'POST'])
@@ -24,6 +33,7 @@ def login():
                 return jsonify({'mensagem': 'Conta expirada'}), 401
             usuario.last_login_at = datetime.utcnow()
             db.session.commit()
+            login_user(usuario)
             token = create_access_token(identity=usuario.id)
             current_app.logger.debug('Login bem-sucedido para usuário %s', login_)
             return jsonify({'access_token': token})
@@ -33,4 +43,5 @@ def login():
 
 @bp.route('/logout')
 def logout():
+    logout_user()
     return redirect(url_for('auth.login'))


### PR DESCRIPTION
## Summary
- restore Flask-Login integration for JWT login
- keep token response and session authentication working simultaneously

## Testing
- `pytest -q` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_686424e367b0832096fa7fbe62d492e7