### PR TITLE
Add family demand management

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,209 @@ def reset_atendimento_sessao():
     session.pop("familia_id", None)
 
 
+def carregar_cadastro_familia(familia_id):
+    """Carrega dados da família e de demandas ativas para a sessão."""
+    familia = db.session.get(Familia, familia_id)
+    if not familia:
+        return None
+
+    cadastro = {}
+    cadastro["novo_cadastro"] = 0
+
+    cadastro.update({
+        "nome_responsavel": familia.nome_responsavel,
+        "data_nascimento": familia.data_nascimento.strftime('%d/%m/%Y') if familia.data_nascimento else None,
+        "genero": familia.genero,
+        "genero_autodeclarado": familia.genero_autodeclarado,
+        "estado_civil": familia.estado_civil,
+        "rg": familia.rg,
+        "cpf": familia.cpf,
+    })
+    if familia.autoriza_uso_imagem is not None:
+        cadastro["autoriza_uso_imagem"] = _bool_to_sim_nao(familia.autoriza_uso_imagem)
+
+    endereco = Endereco.query.filter_by(familia_id=familia_id).first()
+    if endereco:
+        cadastro.update({
+            "preenchimento_manual": endereco.preenchimento_manual,
+            "cep": endereco.cep,
+            "logradouro": endereco.logradouro,
+            "numero": endereco.numero,
+            "complemento": endereco.complemento,
+            "bairro": endereco.bairro,
+            "cidade": endereco.cidade,
+            "estado": endereco.estado,
+            "ponto_referencia": endereco.ponto_referencia,
+        })
+
+    comp = ComposicaoFamiliar.query.filter_by(familia_id=familia_id).first()
+    if comp:
+        cadastro.update({
+            "total_residentes": comp.total_residentes,
+            "quantidade_bebes": comp.quantidade_bebes,
+            "quantidade_criancas": comp.quantidade_criancas,
+            "quantidade_adolescentes": comp.quantidade_adolescentes,
+            "quantidade_adultos": comp.quantidade_adultos,
+            "quantidade_idosos": comp.quantidade_idosos,
+            "motivo_ausencia_escola": comp.motivo_ausencia_escola,
+        })
+        if comp.tem_menores_na_escola is not None:
+            cadastro["menores_na_escola"] = _bool_to_sim_nao(comp.tem_menores_na_escola)
+
+    contato = Contato.query.filter_by(familia_id=familia_id).first()
+    if contato:
+        cadastro.update({
+            "telefone_principal": contato.telefone_principal,
+            "telefone_principal_whatsapp": contato.telefone_principal_whatsapp,
+            "telefone_principal_nome_contato": contato.telefone_principal_nome_contato,
+            "telefone_alternativo": contato.telefone_alternativo,
+            "telefone_alternativo_whatsapp": contato.telefone_alternativo_whatsapp,
+            "telefone_alternativo_nome_contato": contato.telefone_alternativo_nome_contato,
+            "email_responsavel": contato.email_responsavel,
+        })
+
+    cond = CondicaoMoradia.query.filter_by(familia_id=familia_id).first()
+    if cond:
+        cadastro.update({
+            "tipo_moradia": cond.tipo_moradia,
+            "valor_aluguel": str(cond.valor_aluguel) if cond.valor_aluguel is not None else None,
+            "num_camas": cond.quantidade_camas,
+            "num_tvs": cond.quantidade_tvs,
+            "num_ventiladores": cond.quantidade_ventiladores,
+        })
+        if cond.tem_agua_encanada is not None:
+            cadastro["agua_encanada"] = _bool_to_sim_nao(cond.tem_agua_encanada)
+        if cond.tem_rede_esgoto is not None:
+            cadastro["rede_esgoto"] = _bool_to_sim_nao(cond.tem_rede_esgoto)
+        if cond.tem_energia_eletrica is not None:
+            cadastro["energia_eletrica"] = _bool_to_sim_nao(cond.tem_energia_eletrica)
+        if cond.tem_fogao is not None:
+            cadastro["tem_fogao"] = _bool_to_sim_nao(cond.tem_fogao)
+        if cond.tem_geladeira is not None:
+            cadastro["tem_geladeira"] = _bool_to_sim_nao(cond.tem_geladeira)
+
+    saude = SaudeFamiliar.query.filter_by(familia_id=familia_id).first()
+    if saude:
+        cadastro.update({
+            "descricao_doenca_cronica": saude.descricao_doenca_cronica,
+            "descricao_medicacao": saude.descricao_medicacao,
+            "descricao_deficiencia": saude.descricao_deficiencia,
+        })
+        if saude.tem_doenca_cronica is not None:
+            cadastro["tem_doenca_cronica"] = _bool_to_sim_nao(saude.tem_doenca_cronica)
+        if saude.usa_medicacao_continua is not None:
+            cadastro["usa_medicacao_continua"] = _bool_to_sim_nao(saude.usa_medicacao_continua)
+        if saude.tem_deficiencia is not None:
+            cadastro["tem_deficiencia"] = _bool_to_sim_nao(saude.tem_deficiencia)
+        if saude.recebe_bpc is not None:
+            cadastro["recebe_bpc"] = _bool_to_sim_nao(saude.recebe_bpc)
+
+    emprego = EmpregoProvedor.query.filter_by(familia_id=familia_id).first()
+    if emprego:
+        cadastro.update({
+            "relacao_provedor_familia": emprego.relacao_provedor_familia,
+            "descricao_provedor_externo": emprego.descricao_provedor_externo,
+            "situacao_emprego": emprego.situacao_emprego,
+            "descricao_situacao_emprego_outro": emprego.descricao_situacao_emprego_outro,
+            "profissao_provedor": emprego.profissao_provedor,
+            "experiencia_profissional": emprego.experiencia_profissional,
+            "formacao_profissional": emprego.formacao_profissional,
+            "habilidades_relevantes": emprego.habilidades_relevantes,
+        })
+
+    renda = RendaFamiliar.query.filter_by(familia_id=familia_id).first()
+    if renda:
+        cadastro.update({
+            "gastos_supermercado": str(renda.gastos_supermercado) if renda.gastos_supermercado is not None else None,
+            "gastos_energia_eletrica": str(renda.gastos_energia_eletrica) if renda.gastos_energia_eletrica is not None else None,
+            "gastos_agua": str(renda.gastos_agua) if renda.gastos_agua is not None else None,
+            "valor_botija_gas": str(renda.valor_botijao_gas) if renda.valor_botijao_gas is not None else None,
+            "duracao_botija_gas": renda.duracao_botijao_gas,
+            "gastos_gas": str(renda.gastos_gas) if renda.gastos_gas is not None else None,
+            "gastos_transporte": str(renda.gastos_transporte) if renda.gastos_transporte is not None else None,
+            "gastos_medicamentos": str(renda.gastos_medicamentos) if renda.gastos_medicamentos is not None else None,
+            "gastos_conta_celular": str(renda.gastos_celular) if renda.gastos_celular is not None else None,
+            "gastos_outros": str(renda.gastos_outros) if renda.gastos_outros is not None else None,
+            "renda_arrimo": str(renda.renda_provedor_principal) if renda.renda_provedor_principal is not None else None,
+            "renda_outros_familiares": str(renda.renda_outros_moradores) if renda.renda_outros_moradores is not None else None,
+            "auxilio_parentes_amigos": str(renda.ajuda_terceiros) if renda.ajuda_terceiros is not None else None,
+            "descricao_beneficios": renda.descricao_beneficios,
+            "valor_total_beneficios": str(renda.valor_beneficios) if renda.valor_beneficios is not None else None,
+            "renda_familiar_total": str(renda.renda_total_familiar) if renda.renda_total_familiar is not None else None,
+            "total_gastos": str(renda.gastos_totais) if renda.gastos_totais is not None else None,
+            "saldo": str(renda.saldo_mensal) if renda.saldo_mensal is not None else None,
+        })
+        if renda.possui_cadastro_unico is not None:
+            cadastro["cadastro_unico"] = _bool_to_sim_nao(renda.possui_cadastro_unico)
+        if renda.recebe_beneficios_governo is not None:
+            cadastro["recebe_beneficio"] = _bool_to_sim_nao(renda.recebe_beneficios_governo)
+
+    educacao = EducacaoEntrevistado.query.filter_by(familia_id=familia_id).first()
+    if educacao:
+        cadastro.update({
+            "nivel_escolaridade": educacao.nivel_escolaridade,
+            "curso_ou_serie_atual": educacao.curso_ou_serie_atual,
+        })
+        if educacao.estuda_atualmente is not None:
+            cadastro["estuda_atualmente"] = _bool_to_sim_nao(educacao.estuda_atualmente)
+
+    ult_etapa = (
+        db.session.query(
+            DemandaEtapa.demanda_id,
+            func.max(DemandaEtapa.etapa_id).label("etapa_id")
+        )
+        .group_by(DemandaEtapa.demanda_id)
+        .subquery()
+    )
+
+    active_statuses = [
+        "Em análise",
+        "Em andamento",
+        "Encaminhada",
+        "Aguardando resposta",
+        "Suspensa",
+    ]
+
+    demandas_rows = (
+        db.session.query(
+            DemandaFamilia.demanda_id,
+            DemandaTipo.demanda_tipo_nome,
+            DemandaFamilia.descricao,
+            DemandaFamilia.prioridade,
+            DemandaEtapa.status_atual,
+            DemandaEtapa.observacao,
+        )
+        .join(ult_etapa, DemandaFamilia.demanda_id == ult_etapa.c.demanda_id)
+        .join(
+            DemandaEtapa,
+            and_(
+                DemandaEtapa.demanda_id == ult_etapa.c.demanda_id,
+                DemandaEtapa.etapa_id == ult_etapa.c.etapa_id,
+            ),
+        )
+        .join(DemandaTipo, DemandaTipo.demanda_tipo_id == DemandaFamilia.demanda_tipo_id)
+        .filter(DemandaFamilia.familia_id == familia_id)
+        .filter(DemandaFamilia.status.in_(active_statuses))
+        .all()
+    )
+
+    cadastro["demandas"] = [
+        {
+            "demanda_id": row.demanda_id,
+            "categoria": row.demanda_tipo_nome,
+            "descricao": row.descricao,
+            "prioridade": row.prioridade,
+            "status_atual": row.status_atual,
+            "observacao": row.observacao,
+        }
+        for row in demandas_rows
+    ]
+
+    session["cadastro"] = cadastro
+    session["familia_id"] = familia_id
+    return cadastro
+
+
 def _bool_to_sim_nao(valor):
     if valor is None:
         return None
@@ -82,6 +285,57 @@ def menu_atendimento():
             })
         auto_open = True
     return render_template("atendimento/etapa0_menu.html", resultados=resultados, auto_open=auto_open)
+
+
+@app.route("/gerenciar_demandas", methods=["GET"])
+@login_required
+def gerenciar_demandas_busca():
+    """Exibe página de busca de família para gerenciar demandas."""
+    termo = request.args.get("q", "").strip()
+    resultados = None
+    if termo:
+        query = Familia.query.filter(
+            or_(
+                Familia.cpf.ilike(f"%{termo}%"),
+                Familia.nome_responsavel.ilike(f"%{termo}%")
+            )
+        )
+        familias = query.all()
+        resultados = []
+        for familia in familias:
+            ultimo = db.session.query(func.max(Atendimento.data_hora_atendimento)).filter_by(familia_id=familia.familia_id).scalar()
+            resultados.append({
+                "familia_id": familia.familia_id,
+                "nome_responsavel": familia.nome_responsavel,
+                "cpf": familia.cpf,
+                "ultimo_atendimento": ultimo.date() if ultimo else None,
+            })
+    return render_template("demandas/busca_familia.html", resultados=resultados)
+
+
+@app.route("/gerenciar_demandas/<int:familia_id>", methods=["GET", "POST"])
+@login_required
+def gerenciar_demandas_familia(familia_id):
+    """Permite atualização direta das demandas da família."""
+    if request.method == "POST":
+        cadastro = get_cadastro()
+        cadastro.update(request.form.to_dict(flat=True))
+        demandas_json = request.form.get("demandas_json")
+        if demandas_json:
+            try:
+                cadastro["demandas"] = json.loads(demandas_json)
+            except Exception:
+                cadastro["demandas"] = []
+        session["cadastro"] = cadastro
+        flash("Demandas atualizadas", "success")
+        return redirect(url_for("gerenciar_demandas_familia", familia_id=familia_id))
+
+    reset_atendimento_sessao()
+    cadastro = carregar_cadastro_familia(familia_id)
+    if cadastro is None:
+        flash("Família não encontrada", "danger")
+        return redirect(url_for("gerenciar_demandas_busca"))
+    return render_template("demandas/gerenciar.html")
 
 @app.route("/atendimento_nova_familia")
 @login_required

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,8 +20,9 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-            <ul class="navbar-nav align-items-center">                
+            <ul class="navbar-nav align-items-center">
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('menu_atendimento') }}">Atendimento à Família</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('gerenciar_demandas_busca') }}">Gerenciar demandas</a></li>
                 {% if current_user.is_authenticated and current_user.tipo == 'admin' %}
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('usuarios.listar_usuarios') }}">Gerenciar Usuários</a></li>
                 {% endif %}
@@ -36,7 +37,7 @@
 </nav>
 
 <!-- Resumo da Família (Colapsável) -->
-{% if session.get('familia_id') and request.path.startswith('/atendimento/') and session.get('cadastro', {}).get('novo_cadastro') == 0 %}
+{% if session.get('familia_id') and (request.path.startswith('/atendimento/') or request.path.startswith('/gerenciar_demandas')) and session.get('cadastro', {}).get('novo_cadastro') == 0 %}
 <div id="familySummary" class="family-summary">
     <div class="family-summary-header">
         <div class="d-flex align-items-center">

--- a/app/templates/demandas/busca_familia.html
+++ b/app/templates/demandas/busca_familia.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block title %}Gerenciar demandas{% endblock %}
+{% block content %}
+<h2 class="mb-4 text-center">Gerenciar demandas</h2>
+<div class="search-instruction">
+    <i class="fa-solid fa-info-circle"></i>
+    <span>Digite parte do nome ou CPF e clique em Buscar.</span>
+</div>
+<form method="get" class="search-input-group">
+    <input type="text" name="q" class="form-control" placeholder="Digite nome ou CPF" value="{{ request.args.get('q','') }}">
+    <button type="submit" class="btn btn-primary"><i class="fa-solid fa-search"></i> Buscar</button>
+</form>
+{% if resultados is not none %}
+<div id="resultadosContainer" class="mt-3">
+    <ul class="list-group">
+        {% if resultados %}
+            {% for f in resultados %}
+            <li class="list-group-item familia-resultado">
+                <a href="{{ url_for('gerenciar_demandas_familia', familia_id=f.familia_id) }}" class="text-decoration-none familia-link">
+                    <div class="familia-nome">Nome: {{ f.nome_responsavel }}</div>
+                    <div class="familia-cpf">CPF: {{ f.cpf or 'Não informado' }}</div>
+                    {% if f.ultimo_atendimento %}
+                    <div class="familia-atendimento">Atendimento mais recente: {{ f.ultimo_atendimento.strftime('%d/%m/%Y') }}</div>
+                    {% endif %}
+                </a>
+            </li>
+            {% endfor %}
+        {% else %}
+            <li class="list-group-item">Nenhuma família encontrada</li>
+        {% endif %}
+    </ul>
+</div>
+{% endif %}
+{% endblock %}

--- a/app/templates/demandas/gerenciar.html
+++ b/app/templates/demandas/gerenciar.html
@@ -1,0 +1,121 @@
+{% extends 'base.html' %}
+{% block title %}Gerenciar demandas{% endblock %}
+{% block content %}
+<div id="demandasAtivasSection" class="mb-4 d-none">
+    <div class="card shadow-sm border-0">
+        <div class="card-header bg-gradient-info text-white py-3">
+            <div class="d-flex align-items-center">
+                <div class="icon-wrapper me-3">
+                    <i class="fas fa-tasks fa-lg"></i>
+                </div>
+                <div>
+                    <h4 class="mb-0 fw-bold">
+                        Demandas Ativas
+                        <span id="contadorDemandas" class="badge bg-light text-dark ms-2 fs-6">0</span>
+                    </h4>
+                    <small class="opacity-90">Acompanhe o status das necessidades já registradas</small>
+                </div>
+            </div>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table id="tabelaDemandasAtivas" class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th class="border-0 fw-semibold text-muted py-3">
+                                <i class="fas fa-file-alt me-2"></i>Descrição
+                            </th>
+                            <th class="border-0 fw-semibold text-muted py-3">
+                                <i class="fas fa-tags me-2"></i>Categoria
+                            </th>
+                            <th class="border-0 fw-semibold text-muted py-3">
+                                <i class="fas fa-exclamation-triangle me-2"></i>Prioridade
+                            </th>
+                            <th class="border-0 fw-semibold text-muted py-3">
+                                <i class="fas fa-info-circle me-2"></i>Status
+                            </th>
+                            <th class="border-0 fw-semibold text-muted py-3">
+                                <i class="fas fa-comment-alt me-2"></i>Observação
+                            </th>
+                            <th class="border-0 py-3 text-center">
+                                <i class="fas fa-cog"></i>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<p class="text-muted mb-4">
+    Registre abaixo outras necessidades identificadas.
+</p>
+
+<form id="formEtapa10" autocomplete="off" method="post">
+    <input type="hidden" id="familia_id_hidden" name="familia_id" value="{{ session.get('familia_id', '') }}">
+    <input type="hidden" id="demandas_json" name="demandas_json" value="">
+    <div id="necessidadesLista" class="mb-3">
+        <p id="nenhumaNecessidade" class="text-muted">Nenhuma necessidade adicionada ainda.</p>
+    </div>
+    <div class="mb-3">
+        <button type="button" class="btn btn-secondary" id="adicionarNecessidade">
+            <i class="fa fa-plus"></i> Adicionar nova necessidade
+        </button>
+    </div>
+    <div class="text-end">
+        <button type="submit" class="btn btn-primary" id="btnProxima" data-next-url="{{ url_for('gerenciar_demandas_familia', familia_id=session.get('familia_id')) }}">
+            Salvar
+        </button>
+    </div>
+</form>
+
+<div id="modalAtualizarDemanda" class="modal-overlay d-none">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h5 class="modal-title"><i class="fa-solid fa-pen"></i> Atualizar demanda</h5>
+            <button type="button" class="btn-close" id="fecharModalDemanda">&times;</button>
+        </div>
+        <div class="modal-body">
+            <form id="formAtualizarDemanda">
+                <input type="hidden" id="modal_demanda_id">
+                <div class="mb-3">
+                    <label class="form-label">Demanda</label>
+                    <p id="modal_demanda_descricao" class="fw-bold mb-1"></p>
+                </div>
+                <div class="mb-3">
+                    <label for="modal_status" class="form-label">Status atual</label>
+                    <select id="modal_status" class="form-select" required>
+                        <option value="Em análise">Em análise</option>
+                        <option value="Em andamento">Em andamento</option>
+                        <option value="Encaminhada">Encaminhada</option>
+                        <option value="Aguardando resposta">Aguardando resposta</option>
+                        <option value="Suspensa">Suspensa</option>
+                        <option value="Cancelada">Cancelada</option>
+                        <option value="Concluída">Concluída</option>
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label for="modal_observacao" class="form-label">Observação</label>
+                    <textarea id="modal_observacao" class="form-control" rows="3"></textarea>
+                </div>
+                <div class="text-end">
+                    <button type="button" class="btn btn-primary" id="salvarAtualizacaoDemanda">Salvar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/etapa10_outras_necessidades.css') }}">
+{% endblock %}
+
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/etapa10_outras_necessidades.js') }}"></script>
+<script>
+    window.sessionCadastro = {{ session['cadastro'] | tojson }};
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add menu entry 'Gerenciar demandas'
- show family summary also on demand management pages
- provide helper `carregar_cadastro_familia`
- implement routes `/gerenciar_demandas` and `/gerenciar_demandas/<id>`
- new templates for demand search and management

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6868efa41228832086c7a400fec94d63