### PR TITLE
Atualiza modal de edição de demandas

### DIFF
--- a/app/static/js/etapa10_outras_necessidades.js
+++ b/app/static/js/etapa10_outras_necessidades.js
@@ -22,8 +22,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const modal = document.getElementById('modalAtualizarDemanda');
     const fecharModalBtn = document.getElementById('fecharModalDemanda');
     const salvarModalBtn = document.getElementById('salvarAtualizacaoDemanda');
-    const modalStatus = document.getElementById('modal_status');
-    const modalObs = document.getElementById('modal_observacao');
+    const cancelarModalBtn = document.getElementById('cancelarAtualizacaoDemanda');
+    const novoStatusSelect = document.getElementById('modal_novo_status');
+    const novaObs = document.getElementById('modal_nova_observacao');
+    const statusAtualText = document.getElementById('modal_status_atual');
+    const obsAnteriorText = document.getElementById('modal_observacao_anterior');
     const modalDesc = document.getElementById('modal_demanda_descricao');
     const modalId = document.getElementById('modal_demanda_id');
 
@@ -337,8 +340,10 @@ document.addEventListener('DOMContentLoaded', function () {
         const demanda = (window.sessionCadastro.demandas || []).find(d => String(d.demanda_id) === String(id));
         if (!demanda) return;
         modalId.value = demanda.demanda_id;
-        modalStatus.value = demanda.status_atual || 'Em análise';
-        modalObs.value = demanda.observacao || '';
+        statusAtualText.textContent = demanda.status_atual || demanda.status || '—';
+        obsAnteriorText.textContent = demanda.observacao || '—';
+        novoStatusSelect.value = '';
+        novaObs.value = '';
         modalDesc.textContent = demanda.descricao || '';
         modal.classList.remove('d-none');
     });
@@ -348,11 +353,12 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     fecharModalBtn?.addEventListener('click', fecharModal);
+    cancelarModalBtn?.addEventListener('click', fecharModal);
 
     salvarModalBtn?.addEventListener('click', async function () {
         const demId = modalId.value;
-        const status = modalStatus.value;
-        const observacao = modalObs.value.trim();
+        const status = novoStatusSelect.value;
+        const observacao = novaObs.value.trim();
         if (!demId || !status) return;
         salvarModalBtn.disabled = true;
         try {

--- a/app/templates/atendimento/etapa10_outras_necessidades.html
+++ b/app/templates/atendimento/etapa10_outras_necessidades.html
@@ -87,8 +87,17 @@
                     <p id="modal_demanda_descricao" class="fw-bold mb-1"></p>
                 </div>
                 <div class="mb-3">
-                    <label for="modal_status" class="form-label">Status atual</label>
-                    <select id="modal_status" class="form-select" required>
+                    <label class="form-label">Status atual</label>
+                    <p id="modal_status_atual" class="form-control-plaintext mb-0"></p>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Observação anterior</label>
+                    <p id="modal_observacao_anterior" class="form-control-plaintext mb-0"></p>
+                </div>
+                <div class="mb-3">
+                    <label for="modal_novo_status" class="form-label">Novo status</label>
+                    <select id="modal_novo_status" class="form-select" required>
+                        <option value="" selected disabled>Selecione</option>
                         <option value="Em análise">Em análise</option>
                         <option value="Em andamento">Em andamento</option>
                         <option value="Encaminhada">Encaminhada</option>
@@ -99,10 +108,11 @@
                     </select>
                 </div>
                 <div class="mb-3">
-                    <label for="modal_observacao" class="form-label">Observação</label>
-                    <textarea id="modal_observacao" class="form-control" rows="3"></textarea>
+                    <label for="modal_nova_observacao" class="form-label">Observação</label>
+                    <textarea id="modal_nova_observacao" class="form-control" rows="3"></textarea>
                 </div>
-                <div class="text-end">
+                <div class="d-flex justify-content-between">
+                    <button type="button" class="btn btn-secondary" id="cancelarAtualizacaoDemanda">Cancelar</button>
                     <button type="button" class="btn btn-primary" id="salvarAtualizacaoDemanda">Salvar</button>
                 </div>
             </form>

--- a/app/templates/demandas/gerenciar.html
+++ b/app/templates/demandas/gerenciar.html
@@ -85,8 +85,17 @@
                     <p id="modal_demanda_descricao" class="fw-bold mb-1"></p>
                 </div>
                 <div class="mb-3">
-                    <label for="modal_status" class="form-label">Status atual</label>
-                    <select id="modal_status" class="form-select" required>
+                    <label class="form-label">Status atual</label>
+                    <p id="modal_status_atual" class="form-control-plaintext mb-0"></p>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Observação anterior</label>
+                    <p id="modal_observacao_anterior" class="form-control-plaintext mb-0"></p>
+                </div>
+                <div class="mb-3">
+                    <label for="modal_novo_status" class="form-label">Novo status</label>
+                    <select id="modal_novo_status" class="form-select" required>
+                        <option value="" selected disabled>Selecione</option>
                         <option value="Em análise">Em análise</option>
                         <option value="Em andamento">Em andamento</option>
                         <option value="Encaminhada">Encaminhada</option>
@@ -97,10 +106,11 @@
                     </select>
                 </div>
                 <div class="mb-3">
-                    <label for="modal_observacao" class="form-label">Observação</label>
-                    <textarea id="modal_observacao" class="form-control" rows="3"></textarea>
+                    <label for="modal_nova_observacao" class="form-label">Observação</label>
+                    <textarea id="modal_nova_observacao" class="form-control" rows="3"></textarea>
                 </div>
-                <div class="text-end">
+                <div class="d-flex justify-content-between">
+                    <button type="button" class="btn btn-secondary" id="cancelarAtualizacaoDemanda">Cancelar</button>
                     <button type="button" class="btn btn-primary" id="salvarAtualizacaoDemanda">Salvar</button>
                 </div>
             </form>


### PR DESCRIPTION
## Summary
- exibir status e observação atuais somente para leitura
- permitir escolha de novo status e nova observação
- adicionar botão de cancelar

## Testing
- `pytest -q` *(fails: quote_from_bytes expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_6868f4e3596083208d90357ad2ccbfab