### PR TITLE
Add active demands dashboard

### DIFF
--- a/app/static/css/dashboard_demandas.css
+++ b/app/static/css/dashboard_demandas.css
@@ -1,0 +1,10 @@
+#tabelaDemandasAtivas .filtros input {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+}
+
+#paginacaoDemandas {
+    margin-top: 1rem;
+    justify-content: center;
+}

--- a/app/static/js/dashboard_demandas.js
+++ b/app/static/js/dashboard_demandas.js
@@ -1,0 +1,93 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const dados = window.demandasAtivas || [];
+    const tbody = document.querySelector('#tabelaDemandasAtivas tbody');
+    const paginacao = document.getElementById('paginacaoDemandas');
+    const registrosPorPagina = 15;
+    let paginaAtual = 1;
+
+    const filtros = {
+        nome: document.getElementById('filter-nome'),
+        cpf: document.getElementById('filter-cpf'),
+        bairro: document.getElementById('filter-bairro'),
+        descricao: document.getElementById('filter-descricao'),
+        tipo: document.getElementById('filter-tipo'),
+        status: document.getElementById('filter-status'),
+        prioridade: document.getElementById('filter-prioridade')
+    };
+
+    Object.values(filtros).forEach(input => {
+        if (input) {
+            input.addEventListener('input', () => {
+                paginaAtual = 1;
+                renderTable();
+            });
+        }
+    });
+
+    function aplicaFiltros(lista) {
+        return lista.filter(item => {
+            return (!filtros.nome.value || item.nome_responsavel.toLowerCase().includes(filtros.nome.value.toLowerCase())) &&
+                   (!filtros.cpf.value || (item.cpf || '').toLowerCase().includes(filtros.cpf.value.toLowerCase())) &&
+                   (!filtros.bairro.value || (item.bairro || '').toLowerCase().includes(filtros.bairro.value.toLowerCase())) &&
+                   (!filtros.descricao.value || (item.descricao || '').toLowerCase().includes(filtros.descricao.value.toLowerCase())) &&
+                   (!filtros.tipo.value || (item.demanda_tipo_nome || '').toLowerCase().includes(filtros.tipo.value.toLowerCase())) &&
+                   (!filtros.status.value || (item.status_atual || '').toLowerCase().includes(filtros.status.value.toLowerCase())) &&
+                   (!filtros.prioridade.value || (item.prioridade || '').toLowerCase().includes(filtros.prioridade.value.toLowerCase()));
+        });
+    }
+
+    function renderTable() {
+        const filtrados = aplicaFiltros(dados);
+        const totalPaginas = Math.ceil(filtrados.length / registrosPorPagina) || 1;
+        paginaAtual = Math.min(paginaAtual, totalPaginas);
+        const inicio = (paginaAtual - 1) * registrosPorPagina;
+        const paginaDados = filtrados.slice(inicio, inicio + registrosPorPagina);
+
+        tbody.innerHTML = '';
+        paginaDados.forEach(item => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td><a href="/gerenciar_demandas/${item.familia_id}">${item.nome_responsavel}</a></td>
+                <td>${item.cpf || ''}</td>
+                <td>${item.bairro || ''}</td>
+                <td>${item.descricao || ''}</td>
+                <td>${formatarData(item.data_identificacao)}</td>
+                <td>${item.demanda_tipo_nome || ''}</td>
+                <td>${item.status_atual || ''}</td>
+                <td>${item.prioridade || ''}</td>
+                <td>${formatarData(item.data_atualizacao)}</td>
+                <td>${item.observacao || ''}</td>`;
+            tbody.appendChild(tr);
+        });
+
+        renderPaginacao(totalPaginas);
+    }
+
+    function renderPaginacao(total) {
+        paginacao.innerHTML = '';
+        for (let i = 1; i <= total; i++) {
+            const li = document.createElement('li');
+            li.className = 'page-item' + (i === paginaAtual ? ' active' : '');
+            const a = document.createElement('a');
+            a.href = '#';
+            a.className = 'page-link';
+            a.textContent = i;
+            a.addEventListener('click', (e) => {
+                e.preventDefault();
+                paginaAtual = i;
+                renderTable();
+            });
+            li.appendChild(a);
+            paginacao.appendChild(li);
+        }
+    }
+
+    function formatarData(data) {
+        if (!data) return '';
+        const d = new Date(data);
+        if (isNaN(d)) return data;
+        return d.toLocaleDateString('pt-BR');
+    }
+
+    renderTable();
+});

--- a/app/templates/dashboards/dashboard.html
+++ b/app/templates/dashboards/dashboard.html
@@ -95,9 +95,11 @@
             setTimeout(() => {
                 this.style.transform = 'translateY(-3px)';
             }, 100);
-            
-            // Aqui futuramente será adicionado o redirecionamento para relatórios específicos
-            console.log('Card clicado:', this.querySelector('.card-title').textContent);
+
+            const title = this.querySelector('.card-title').textContent.trim();
+            if (title === 'Famílias com demandas ativas') {
+                window.location.href = "{{ url_for('dashboard_demandas_ativas') }}";
+            }
         });
     });
 

--- a/app/templates/dashboards/demandas_ativas.html
+++ b/app/templates/dashboards/demandas_ativas.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block title %}Demandas Ativas{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_demandas.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="dashboard-header">
+    <h1>
+        <i class="fas fa-exclamation-triangle"></i>
+        Demandas Ativas
+    </h1>
+    <p>Famílias com demandas em andamento</p>
+</div>
+<div class="table-responsive">
+    <table id="tabelaDemandasAtivas" class="table table-hover align-middle">
+        <thead class="table-light">
+            <tr>
+                <th>Nome do responsável</th>
+                <th>CPF</th>
+                <th>Bairro</th>
+                <th>Descrição</th>
+                <th>Data Identificação</th>
+                <th>Tipo</th>
+                <th>Status</th>
+                <th>Prioridade</th>
+                <th>Atualização</th>
+                <th>Observação</th>
+            </tr>
+            <tr class="filtros">
+                <th><input id="filter-nome" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th><input id="filter-cpf" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th><input id="filter-bairro" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th><input id="filter-descricao" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th></th>
+                <th><input id="filter-tipo" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th><input id="filter-status" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th><input id="filter-prioridade" class="form-control form-control-sm" placeholder="Filtrar"></th>
+                <th></th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<nav>
+    <ul class="pagination" id="paginacaoDemandas"></ul>
+</nav>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    window.demandasAtivas = {{ demandas | tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/dashboard_demandas.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add route `/dashboard/demandas-ativas`
- create template `demandas_ativas.html`
- add JS and CSS for client-side filter and pagination
- update dashboard card to link to the new page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_686d1614b7908320a570341628f133c2