### PR TITLE
Corrige exibição do resumo de família

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ def menu_atendimento():
 @login_required
 def gerenciar_demandas_busca():
     """Exibe página de busca de família para gerenciar demandas."""
+    reset_atendimento_sessao()
     termo = request.args.get("q", "").strip()
     resultados = None
     if termo:


### PR DESCRIPTION
## Summary
- limpa a sessão ao acessar `/gerenciar_demandas` para que o resumo da família não apareça na página de busca

## Testing
- `pytest -q` *(falha: ModuleNotFoundError: No module named 'playwright', TypeError: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_686d524a66b083209ff189d06c3eec8e