### PR TITLE
Add Excel export for families attended in last 30 days

### DIFF
--- a/app/static/css/familias_atendidas_30_dias.css
+++ b/app/static/css/familias_atendidas_30_dias.css
@@ -6,6 +6,16 @@
     gap: 2rem;
 }
 
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.header-actions .btn {
+    white-space: nowrap;
+}
+
 .header-text h1 {
     color: white;
     font-weight: 700;

--- a/app/static/js/familias_atendidas_30_dias.js
+++ b/app/static/js/familias_atendidas_30_dias.js
@@ -1,4 +1,38 @@
 document.addEventListener('DOMContentLoaded', function () {
+    const downloadBtn = document.getElementById('downloadBtn');
+    if (downloadBtn) {
+        const downloadUrl = downloadBtn.dataset.url;
+        downloadBtn.addEventListener('click', () => {
+            fetch(downloadUrl, {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                }
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Erro ao gerar arquivo');
+                }
+                return response.blob();
+            })
+            .then(blob => {
+                const url = window.URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                const now = new Date();
+                const dateStr = now.getFullYear() + '_' + String(now.getMonth() + 1).padStart(2, '0') + '_' + String(now.getDate()).padStart(2, '0');
+                link.href = url;
+                link.download = `familias_atendidas_30_dias_${dateStr}.xlsx`;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                window.URL.revokeObjectURL(url);
+            })
+            .catch(error => {
+                console.error('Erro no download:', error);
+            });
+        });
+    }
+
     const dados = window.familiasAtendidas || [];
     const tbody = document.querySelector('#tabelaFamiliasAtendidas tbody');
     const paginacao = document.getElementById('paginacaoFamiliasAtendidas');

--- a/app/templates/dashboards/familias_atendidas_30_dias.html
+++ b/app/templates/dashboards/familias_atendidas_30_dias.html
@@ -17,10 +17,16 @@
             </h1>
             <p>Listagem de famílias que receberam atendimento no período</p>
         </div>
-        <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">
-            <i class="fas fa-arrow-left"></i>
-            Voltar ao Dashboard
-        </a>
+        <div class="header-actions">
+            <button id="downloadBtn" class="btn btn-primary" data-url="{{ url_for('download_familias_atendidas_30_dias') }}">
+                <i class="fas fa-file-excel"></i>
+                Baixar Excel
+            </button>
+            <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">
+                <i class="fas fa-arrow-left"></i>
+                Voltar ao Dashboard
+            </a>
+        </div>
     </div>
 </div>
 <div class="table-responsive">

--- a/main.py
+++ b/main.py
@@ -603,5 +603,133 @@ def download_familias_cadastradas():
         }), 500
 
 
+@app.route("/dashboard/familias-atendidas-30-dias/download")
+@login_required
+@admin_required
+def download_familias_atendidas_30_dias():
+    """Download de arquivo Excel com dados completos das famílias atendidas nos últimos 30 dias."""
+    try:
+        sql_query_string = """
+        SELECT
+            f.*,
+            e.*,
+            c.*,
+            cf.*,
+            cm.*,
+            ed.*,
+            ep.*,
+            rf.*,
+            sf.*,
+            demandas_json.demandas,
+            atendimentos_json.atendimentos
+        FROM familias f
+        LEFT JOIN enderecos e ON f.familia_id = e.familia_id
+        LEFT JOIN contatos c ON f.familia_id = c.familia_id
+        LEFT JOIN composicao_familiar cf ON f.familia_id = cf.familia_id
+        LEFT JOIN condicoes_moradia cm ON f.familia_id = cm.familia_id
+        LEFT JOIN educacao_entrevistado ed ON f.familia_id = ed.familia_id
+        LEFT JOIN emprego_provedor ep ON f.familia_id = ep.familia_id
+        LEFT JOIN renda_familiar rf ON f.familia_id = rf.familia_id
+        LEFT JOIN saude_familiar sf ON f.familia_id = sf.familia_id
+        OUTER APPLY (
+            SELECT
+                df.demanda_id,
+                df.familia_id,
+                df.demanda_tipo_id,
+                dt.demanda_tipo_nome,
+                df.status,
+                df.descricao,
+                df.data_identificacao,
+                df.prioridade,
+                de.data_atualizacao,
+                de.status_atual,
+                de.observacao,
+                de.usuario_atualizacao
+            FROM demanda_familia df
+            INNER JOIN demanda_tipo dt ON df.demanda_tipo_id = dt.demanda_tipo_id
+            INNER JOIN demanda_etapa de ON df.demanda_id = de.demanda_id
+            WHERE df.familia_id = f.familia_id
+            FOR JSON PATH
+        ) AS demandas_json(demandas)
+        OUTER APPLY (
+            SELECT
+                a.*
+            FROM atendimentos a
+            WHERE a.familia_id = f.familia_id
+            FOR JSON PATH
+        ) AS atendimentos_json(atendimentos)
+        WHERE EXISTS (
+            SELECT 1 FROM atendimentos a2
+            WHERE a2.familia_id = f.familia_id
+              AND a2.data_hora_atendimento >= DATEADD(DAY, -30, GETDATE())
+        )
+        """
+
+        sql_query = text(sql_query_string)
+        resultados = db.session.execute(sql_query).mappings().all()
+        if not resultados:
+            return jsonify({"error": "Nenhum dado encontrado para exportação"}), 404
+
+        dados = [dict(r) for r in resultados]
+        df = pd.DataFrame(dados)
+
+        for column in df.columns:
+            if df[column].dtype == 'object':
+                sample_values = df[column].dropna().head(5)
+                if len(sample_values) > 0:
+                    first_value = sample_values.iloc[0]
+                    if hasattr(first_value, 'tzinfo') and first_value.tzinfo is not None:
+                        df[column] = pd.to_datetime(df[column], errors='ignore').dt.tz_localize(None)
+            elif 'datetime64[ns, ' in str(df[column].dtype):
+                df[column] = df[column].dt.tz_localize(None)
+
+        colunas_pt = {
+            'familia_id': 'ID Família',
+            'nome_responsavel': 'Nome do Responsável',
+            'cpf': 'CPF',
+            'data_nascimento': 'Data de Nascimento',
+            'telefone_principal': 'Telefone Principal',
+            'email': 'Email',
+            'data_cadastro': 'Data de Cadastro',
+            'logradouro': 'Logradouro',
+            'numero': 'Número',
+            'complemento': 'Complemento',
+            'bairro': 'Bairro',
+            'cidade': 'Cidade',
+            'estado': 'Estado',
+            'cep': 'CEP'
+        }
+        colunas_existentes = {k: v for k, v in colunas_pt.items() if k in df.columns}
+        df = df.rename(columns=colunas_existentes)
+
+        output = BytesIO()
+        with pd.ExcelWriter(output, engine='openpyxl') as writer:
+            df.to_excel(writer, sheet_name='Dados_Familias', index=False)
+            workbook = writer.book
+            worksheet = writer.sheets['Dados_Familias']
+            for column in worksheet.columns:
+                max_length = 0
+                column_letter = column[0].column_letter
+                for cell in column:
+                    try:
+                        if cell.value and len(str(cell.value)) > max_length:
+                            max_length = len(str(cell.value))
+                    except:
+                        pass
+                adjusted_width = min(max(max_length + 2, 10), 50)
+                worksheet.column_dimensions[column_letter].width = adjusted_width
+        output.seek(0)
+
+        data_atual = datetime.now().strftime("%Y_%m_%d")
+        nome_arquivo = f"familias_atendidas_30_dias_{data_atual}.xlsx"
+        return send_file(
+            output,
+            as_attachment=True,
+            download_name=nome_arquivo,
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+    except Exception as e:
+        return jsonify({"error": f"Erro ao gerar arquivo: {str(e)}"}), 500
+
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- add download button to familias_atendidas_30_dias dashboard
- implement backend route to export Excel for families served in last 30 days
- wire up JS and styles for new download feature
- document Excel export pattern and standardize wording in Portuguese

## Testing
- `pytest` *(fails: quote_from_bytes() expected bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68c5843cbdbc8320900553614e0a017b